### PR TITLE
fix: improve release notes retrieval in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # マージされた PR のタイトルと本文を取得してリリースノートにする
-          PR_DATA=$(gh pr view ${{ github.event.pull_request.number }} --json title,body --template '{{.title}}{{"\n\n"}}{{.body}}') || \
+          # 現在のコミットに関連するマージ済み PR のタイトルと本文を取得してリリースノートにする
+          PR_DATA=$(gh pr list --commit ${{ github.sha }} --state merged --json title,body --jq '.[0] | .title + "\n\n" + .body') || \
           PR_DATA=$(git log -1 --pretty=%B) # フォールバック
 
           gh release create ${{ steps.get_version.outputs.tag }} \


### PR DESCRIPTION
This PR fixes the issue where the release workflow failed to retrieve Pull Request information when running on the `main` branch after a merge.

### Changes
- Updated `release.yml` to use `gh pr list --commit ${{ github.sha }}` instead of `gh pr view`.
- This ensures that the workflow can accurately find and extract the title and body of the merged PR to use as release notes, even when the current context is the `main` branch.

Please merge this to ensure high-quality, automated release notes for all future releases.