### PR TITLE
fix: allow ctrl+s shortcut during editing (issue #23)

### DIFF
--- a/src/renderer/src/components/KeyboardShortcuts.svelte
+++ b/src/renderer/src/components/KeyboardShortcuts.svelte
@@ -16,6 +16,9 @@
    * 全選択アクションを実行します。
    */
   const handleSelectAll = (e: KeyboardEvent): void => {
+    if (isEditing()) {
+      return;
+    }
     e.preventDefault();
     selectionState.selectAll(trackStore.tracks);
   };
@@ -38,9 +41,7 @@
 
     switch (e.key.toLowerCase()) {
       case 'a':
-        if (!isEditing()) {
-          handleSelectAll(e);
-        }
+        handleSelectAll(e);
         break;
       case 's':
         handleSave(e);

--- a/src/renderer/src/components/KeyboardShortcuts.svelte
+++ b/src/renderer/src/components/KeyboardShortcuts.svelte
@@ -32,13 +32,15 @@
    * Modifier (Ctrl/Cmd) 系ショートカット（Save, SelectAll など）を処理します。
    */
   const handleModifierShortcuts = (e: KeyboardEvent): void => {
-    if (uiState.isLoading || isEditing()) {
+    if (uiState.isLoading) {
       return;
     }
 
     switch (e.key.toLowerCase()) {
       case 'a':
-        handleSelectAll(e);
+        if (!isEditing()) {
+          handleSelectAll(e);
+        }
         break;
       case 's':
         handleSave(e);


### PR DESCRIPTION
## 概要
テキストボックスなどの入力要素にフォーカスがある場合でも、Ctrl+S（保存）ショートカットが動作するように変更しました。

## 変更内容
- `KeyboardShortcuts.svelte` 内のショートカットガード条件を修正
  - `Ctrl+S`: 編集状態に関わらず常に実行可能に。
  - `Ctrl+A`: 入力要素フォーカス時はブラウザ標準のテキスト全選択を優先し、非フォーカス時のみアプリの全トラック選択を実行。

## 検証内容
- `pnpm lint`: PASS
- `pnpm build`: PASS

Closes #23