### PR TITLE
chore: release v0.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",


### PR DESCRIPTION
## 概要
Issue #23 の修正を反映したリリース作成のため、`package.json` のバージョンを `0.12.2` に更新しました。

## 変更内容
- `package.json`: version `0.12.1` -> `0.12.2`

## 影響
このPRを `main` ブランチにマージすることで、GitHub Actions の `Release` ワークフローが起動し、新規リリースが作成されます。

## 検証内容
- `pnpm test`: PASS