### PR TITLE
feat: add lint and format checks to GitHub Actions (issue #29)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,56 @@
-name: Test
+name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: リポジトリのチェックアウト
+        uses: actions/checkout@v6
+
+      - name: Node.js のセットアップ
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: pnpm のセットアップ
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+
+      - name: 依存関係のインストール
+        run: pnpm install
+
+      - name: Lint の実行
+        run: pnpm lint
+
+  format:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: リポジトリのチェックアウト
+        uses: actions/checkout@v6
+
+      - name: Node.js のセットアップ
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: pnpm のセットアップ
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+
+      - name: 依存関係のインストール
+        run: pnpm install
+
+      - name: フォーマットチェックの実行
+        run: pnpm format:check
+
   test:
     name: Vitest
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <img src="https://img.shields.io/github/v/release/super-kato/TagUtil?style=flat-square" alt="Release">
   <img src="https://img.shields.io/github/license/super-kato/TagUtil?style=flat-square" alt="License">
-  <img src="https://img.shields.io/github/actions/workflow/status/super-kato/TagUtil/test.yml?label=test&style=flat-square" alt="Test Status">
+  <img src="https://img.shields.io/github/actions/workflow/status/super-kato/TagUtil/test.yml?label=CI&style=flat-square" alt="CI Status">
   <img src="https://img.shields.io/github/actions/workflow/status/super-kato/TagUtil/release.yml?style=flat-square" alt="Build Status">
 </p>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "tag-util",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",
   "homepage": "https://electron-vite.org",
   "scripts": {
     "format": "prettier --plugin prettier-plugin-svelte --write .",
+    "format:check": "prettier --plugin prettier-plugin-svelte --check .",
     "lint": "eslint --cache .",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json",
     "svelte-check": "svelte-check --tsconfig ./tsconfig.json",


### PR DESCRIPTION
## 概要
Issue #29 に基づき、GitHub Actions による CI ワークフローを強化しました。

## 変更内容
- **package.json**: 
  - `"format:check"` スクリプトを追加しました。これはフォーマットの正しさを検証するための非破壊的なコマンドです。
  - バージョンを `0.12.3` に更新しました。
- **.github/workflows/test.yml**:
  - ワークフロー名を `CI` に変更しました。
  - トリガーを `pull_request` のみに限定し、不要な `push` 時の実行を削減しました。
  - `Lint`, `Format Check`, `Vitest` を独立したジョブとして定義し、GitHub Actions 上で並列実行されるようにしました。

## 検証内容
ローカル環境にて以下のコマンドが正常に動作することを確認済みです。
- `pnpm lint`: PASS
- `pnpm format:check`: PASS
- `pnpm test`: PASS

Closes #29