### PR TITLE
fix: genre badge removal logic (issue #28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/src/renderer/src/components/inspector/BadgeField.svelte
+++ b/src/renderer/src/components/inspector/BadgeField.svelte
@@ -8,7 +8,7 @@
     isUniform: boolean;
     placeholder?: string;
     onAdd: (value: string) => void;
-    onRemove: (index: number) => void;
+    onRemove: (value: string) => void;
   }
 
   let { label, values, isUniform, onAdd, onRemove }: Props = $props();
@@ -25,7 +25,7 @@
       }
     } else if (e.key === 'Backspace' && inputValue === '' && values.length > 0) {
       // 入力欄が空の状態でバックスペースを押すと最後の項目を削除
-      onRemove(values.length - 1);
+      onRemove(values[values.length - 1]);
     }
   };
 
@@ -52,7 +52,7 @@
       {#each values as val, i (i)}
         <span class="badge">
           {val}
-          <button type="button" class="remove-btn" onclick={() => onRemove(i)} title="Remove">
+          <button type="button" class="remove-btn" onclick={() => onRemove(val)} title="Remove">
             <X size={UI_TOKENS.icons.sizeSmall} strokeWidth={UI_TOKENS.icons.strokeBold} />
           </button>
         </span>

--- a/src/renderer/src/components/inspector/GenreSection.svelte
+++ b/src/renderer/src/components/inspector/GenreSection.svelte
@@ -24,7 +24,7 @@
       values={genreState.type === 'uniform' ? (genreState.value ?? []) : []}
       isUniform={genreState.type === 'uniform'}
       onAdd={(v) => applyGenre(v)}
-      onRemove={(i) => tagActions.removeSelectedMultiFieldValue('genre', i)}
+      onRemove={(v) => tagActions.removeSelectedMultiFieldValue('genre', v)}
     />
 
     <div class="quick-genres">


### PR DESCRIPTION
## 概要
Issue #28 に基づき、Genreバッジの削除ボタン（xボタン）が機能しない問題を修正しました。

## 変更内容
- **BadgeField.svelte**:
  - `onRemove` コールバックがインデックス（数値）ではなく値（文字列）を渡すように修正しました。
  - バックスペースによる削除時も値を渡すように修正しました。
- **GenreSection.svelte**:
  - `BadgeField` から渡される値を受け取り、そのまま `tagActions.removeSelectedMultiFieldValue` に渡すように修正しました。
- **package.json**:
  - バージョンを `0.12.5` に更新しました。

## 影響範囲
`BadgeField` コンポーネントを使用している箇所に影響がありますが、現状 `GenreSection` のみが使用者であることを確認済みです。他の複数値フィールド（Artist等）は `MultiValueField` を使用しており、そちらは元々正しいロジックで動作していました。

## 検証内容
コードロジックの修正により、`BadgeField` と `GenreSection` 間のインターフェース不一致が解消されたことを確認しました。
※環境上の制約により、ローカルでのコマンド実行（lint/test）が失敗したため、CIでの検証をお願いします。

Closes #28