### PR TITLE
chore: allow electron build scripts in workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
-  electron: false
+  electron: true
   electron-winstaller: false
   esbuild: false


### PR DESCRIPTION
## 概要
開発コンテナ再構築時に Electron のデバッグが正常に行えない問題を解決するため、`pnpm-workspace.yaml` の `allowBuilds` 設定を修正しました。

## 変更内容
- **pnpm-workspace.yaml**: `electron` のビルドスクリプト実行を許可 (`true`) に変更しました。
- **package.json**: バージョンを `0.12.6` に更新しました。

## 影響範囲
`pnpm install` 実行時に `electron` パッケージのビルドスクリプトが実行されるようになります。これにより、必要なバイナリのセットアップなどが正しく行われるようになります。

## 検証内容
- ファイル内容の修正を完了。
- ※環境上の制約により、ローカルでの `pnpm install` 実行が制限されたため、マージ後に手動またはCIでの確認をお願いします。