### PR TITLE
fix: エラーメッセージが正常にクリアされない問題を修正 (issue #27)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/src/renderer/src/services/tag-actions.ts
+++ b/src/renderer/src/services/tag-actions.ts
@@ -109,13 +109,13 @@ const applyAutoNumbering = (): void => {
  * 選択中の変更を破棄して再読み込みします。
  */
 const revertSelected = async (): Promise<void> => {
+  uiState.clearError();
   const modifiedSelected = trackStore.selectedTracks.filter((t) => t.isModified);
   if (modifiedSelected.length === 0) {
     return;
   }
 
   uiState.startLoading();
-  uiState.clearError();
 
   try {
     for (const track of modifiedSelected) {
@@ -138,12 +138,12 @@ const revertSelected = async (): Promise<void> => {
  * 変更があったすべてのトラックを保存します。
  */
 const saveAllModified = async (): Promise<void> => {
+  uiState.clearError();
   const modified = trackStore.tracks.filter((t) => t.isModified);
   if (modified.length === 0) {
     return;
   }
 
-  uiState.clearError();
   uiState.startLoading();
 
   try {

--- a/src/renderer/src/services/tag-actions.ts
+++ b/src/renderer/src/services/tag-actions.ts
@@ -82,6 +82,7 @@ const removeSelectedMultiFieldValue = (key: EditableMultiKey, value: string): vo
  * 画像ファイルを選択し、選択中のトラックに適用します。
  */
 const pickAndApplyPicture = async (): Promise<void> => {
+  uiState.clearError();
   const result = await tagIoService.pickImage();
   if (result.type === 'error') {
     uiState.setError(result);
@@ -142,6 +143,7 @@ const saveAllModified = async (): Promise<void> => {
     return;
   }
 
+  uiState.clearError();
   uiState.startLoading();
 
   try {


### PR DESCRIPTION
## 概要
Issue #27 に基づき、エラーメッセージを適切なタイミングでクリアするように修正しました。

## 変更内容
- **tag-actions.ts**:
  - `saveAllModified`（全保存）および `pickAndApplyPicture`（画像選択）アクションの開始時に `uiState.clearError()` を呼び出すようにしました。
- **package.json**:
  - バージョンを `0.12.7` に更新しました。

## 影響範囲
以前のエラーが残ったまま新しい操作を行なった際、成功してもエラーメッセージが表示され続ける問題が解消されます。また、古いエラー状態が後続の操作（ファイルリネームなど）のループを中断させる問題も防げます。

## 検証内容
- `pnpm lint`: PASS
- `pnpm format:check`: PASS
- `pnpm test`: PASS
- `pnpm build`: PASS

Closes #27