### PR TITLE
docs: README.mdのバッジにリソースへのリンクを追加 (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/github/v/release/super-kato/TagUtil?style=flat-square" alt="Release">
-  <img src="https://img.shields.io/github/license/super-kato/TagUtil?style=flat-square" alt="License">
-  <img src="https://img.shields.io/github/actions/workflow/status/super-kato/TagUtil/test.yml?label=CI&style=flat-square" alt="CI Status">
-  <img src="https://img.shields.io/github/actions/workflow/status/super-kato/TagUtil/release.yml?style=flat-square" alt="Build Status">
+  <a href="https://github.com/super-kato/TagUtil/releases"><img src="https://img.shields.io/github/v/release/super-kato/TagUtil?style=flat-square" alt="Release"></a>
+  <a href="https://github.com/super-kato/TagUtil/blob/main/LICENSE"><img src="https://img.shields.io/github/license/super-kato/TagUtil?style=flat-square" alt="License"></a>
+  <a href="https://github.com/super-kato/TagUtil/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/super-kato/TagUtil/test.yml?label=CI&style=flat-square" alt="CI Status"></a>
+  <a href="https://github.com/super-kato/TagUtil/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/super-kato/TagUtil/release.yml?style=flat-square" alt="Build Status"></a>
 </p>
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",


### PR DESCRIPTION
## 概要
README.md の各バッジに、対応するリソースへのリンクを追加しました。

## 変更内容
- **Release バッジ**: [Releases Page](https://github.com/super-kato/TagUtil/releases) へのリンクを追加
- **License バッジ**: [LICENSE](https://github.com/super-kato/TagUtil/blob/main/LICENSE) へのリンクを追加
- **CI Status バッジ**: [test.yml workflow](https://github.com/super-kato/TagUtil/actions/workflows/test.yml) へのリンクを追加
- **Build Status バッジ**: [release.yml workflow](https://github.com/super-kato/TagUtil/actions/workflows/release.yml) へのリンクを追加

Closes #34