### PR TITLE
feat: ツールバーにタグアイコンを追加 #35

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/src/renderer/src/components/Toolbar.svelte
+++ b/src/renderer/src/components/Toolbar.svelte
@@ -22,7 +22,7 @@
 <header class="toolbar">
   <div class="brand">
     <Tag
-      size={UI_TOKENS.icons.size}
+      size={UI_TOKENS.icons.logoSize}
       color="var(--accent-primary)"
       strokeWidth={UI_TOKENS.icons.strokeBold}
     />

--- a/src/renderer/src/components/Toolbar.svelte
+++ b/src/renderer/src/components/Toolbar.svelte
@@ -23,8 +23,9 @@
   <div class="brand">
     <Tag
       size={UI_TOKENS.icons.logoSize}
-      color="var(--accent-primary)"
+      color="var(--text-primary)"
       strokeWidth={UI_TOKENS.icons.strokeBold}
+      class="logo-icon"
     />
     <h1>TagUtil</h1>
   </div>
@@ -85,10 +86,15 @@
     gap: 0.6rem;
   }
 
+  :global(.brand .logo-icon) {
+    margin-top: 0.1rem; /* 視覚的な中央揃えの微調整 */
+  }
+
   .brand h1 {
     font-size: 1.2rem;
     font-weight: 300;
     margin: 0;
+    line-height: 1;
     letter-spacing: 1px;
     color: var(--text-primary);
   }

--- a/src/renderer/src/components/Toolbar.svelte
+++ b/src/renderer/src/components/Toolbar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { UI_TOKENS } from '@renderer/constants/design-system';
-  import { Disc3, FilePen, FolderOpen, RotateCcw, Save } from 'lucide-svelte';
+  import { Disc3, FilePen, FolderOpen, RotateCcw, Save, Tag } from 'lucide-svelte';
   import { tagActions } from '../services/tag-actions';
   import { fileActions } from '../services/file-actions';
   import { trackStore } from '../stores/track-store.svelte';
@@ -21,6 +21,11 @@
 
 <header class="toolbar">
   <div class="brand">
+    <Tag
+      size={UI_TOKENS.icons.size}
+      color="var(--accent-primary)"
+      strokeWidth={UI_TOKENS.icons.strokeBold}
+    />
     <h1>TagUtil</h1>
   </div>
   <div class="actions">
@@ -72,6 +77,12 @@
     align-items: center;
     background-color: var(--bg-inspector);
     border-bottom: 1px solid var(--border-primary);
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
   }
 
   .brand h1 {

--- a/src/renderer/src/constants/design-system.ts
+++ b/src/renderer/src/constants/design-system.ts
@@ -13,6 +13,8 @@ export const UI_TOKENS = {
     /** Lucideアイコンなどの標準的な線の太さ */
     strokeWidth: 1.5,
     /** 小さなアイコンでも視認性を確保するための太めの線 */
-    strokeBold: 2.5
+    strokeBold: 2.5,
+    /** ツールバーのロゴなどに使用するアイコンサイズ (px) */
+    logoSize: 22
   }
 } as const;


### PR DESCRIPTION
ツールバーのアプリ名「TagUtil」の横にタグアイコンを追加しました。

### 変更内容
- `Toolbar.svelte`:
    - `lucide-svelte` の `Tag` アイコンを追加。
    - デザインシステムに基づいたスタイル調整を行い、アイコンとテキストの横並びを整えました。
- `package.json`: バージョンを `0.12.9` に更新。

### 検証内容
- `pnpm lint`: PASS
- `pnpm build`: PASS
- `pnpm test`: PASS