### PR TITLE
fix: アートワーク削除ボタンのホバー時の色をオレンジに修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -140,7 +140,7 @@
   }
 
   .remove-artwork:hover {
-    background: #ff3b30;
+    background: var(--accent-modified);
     opacity: 1;
     transform: scale(1.1);
   }


### PR DESCRIPTION
GitHub Issue: #37

アートワーク削除ボタンのホバー時の色が赤色（#ff3b30）になっていたため、`BadgeField` などの他の削除アクションと整合性をとるためにオレンジ色（`var(--accent-modified)`）に変更しました。

### 実施内容
- `src/renderer/src/components/inspector/ArtworkSection.svelte` の修正
- `package.json` のバージョンを `0.12.12` に更新

### 検証内容
- ビルドおよびテストの成功を確認
- `pnpm lint` で構文エラーがないことを確認