### PR TITLE
feat: アートワークのドラッグ&ドロップ機能の実装 (#26)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.12.12",
+  "version": "0.13.0",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",
@@ -30,6 +30,7 @@
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/tsconfig": "^2.0.0",
     "@electron-toolkit/utils": "^4.0.0",
+    "@lucide/svelte": "^1.8.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.0",
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^4.1.4",
@@ -42,7 +43,6 @@
     "eslint-plugin-svelte": "^3.13.1",
     "flac-tagger": "^2.0.0",
     "license-checker-rseidelsohn": "^4.4.2",
-    "lucide-svelte": "^1.0.1",
     "music-metadata": "^11.12.3",
     "prettier": "^3.8.3",
     "prettier-plugin-svelte": "^3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@41.2.1)
+      '@lucide/svelte':
+        specifier: ^1.8.0
+        version: 1.8.0(svelte@5.55.4(@typescript-eslint/types@8.58.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.0
         version: 6.2.4(svelte@5.55.4(@typescript-eslint/types@8.58.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1))
@@ -59,9 +62,6 @@ importers:
       license-checker-rseidelsohn:
         specifier: ^4.4.2
         version: 4.4.2
-      lucide-svelte:
-        specifier: ^1.0.1
-        version: 1.0.1(svelte@5.55.4(@typescript-eslint/types@8.58.0))
       music-metadata:
         specifier: ^11.12.3
         version: 11.12.3
@@ -639,6 +639,11 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lucide/svelte@1.8.0':
+    resolution: {integrity: sha512-+zYQUKqEOVP5lxbGmxL1OVgGMQtRK91eIJ0bR+3Cr1ts4oQEsQfxyzzd5X47psJlblAuGFrl2xm4YuATjR9oaA==}
+    peerDependencies:
+      svelte: ^5
 
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
@@ -1987,11 +1992,6 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
-
-  lucide-svelte@1.0.1:
-    resolution: {integrity: sha512-WvzZgk0pqzgda+AErLvgWxHkfg/+GgUwqKMRHvzt0IqyMdmyEDzDCk3Z+Wo/3y753oIgx8u9Q4eUbWkghFa8Jg==}
-    peerDependencies:
-      svelte: ^3 || ^4 || ^5.0.0-next.42
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3349,6 +3349,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lucide/svelte@1.8.0(svelte@5.55.4(@typescript-eslint/types@8.58.0))':
+    dependencies:
+      svelte: 5.55.4(@typescript-eslint/types@8.58.0)
 
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
@@ -4858,10 +4862,6 @@ snapshots:
       yallist: 4.0.0
 
   lru-cache@7.18.3: {}
-
-  lucide-svelte@1.0.1(svelte@5.55.4(@typescript-eslint/types@8.58.0)):
-    dependencies:
-      svelte: 5.55.4(@typescript-eslint/types@8.58.0)
 
   magic-string@0.30.21:
     dependencies:

--- a/src/domain/file-extensions.ts
+++ b/src/domain/file-extensions.ts
@@ -1,0 +1,9 @@
+/**
+ * サポートされている音声ファイルの拡張子リスト
+ */
+export const SUPPORTED_AUDIO_EXTENSIONS: readonly string[] = ['.flac'];
+
+/**
+ * サポートされている画像ファイルの拡張子リスト
+ */
+export const SUPPORTED_IMAGE_EXTENSIONS: readonly string[] = ['.jpg', '.jpeg', '.png', '.webp'];

--- a/src/main/ipc/flac-handlers.ts
+++ b/src/main/ipc/flac-handlers.ts
@@ -1,5 +1,5 @@
 import { FlacTrack } from '@domain/flac/types';
-import { pickImage } from '@services/flac/image';
+import { getImageInfo, pickImage } from '@services/flac/image';
 import { readMetadata } from '@services/flac/reader';
 import { renameFile } from '@services/flac/renamer';
 import { scanDirectory } from '@services/flac/scanner';
@@ -23,6 +23,10 @@ export const registerFlacHandlers = (): void => {
 
   ipcMain.handle(IPC_CHANNELS.PICK_IMAGE, async () => {
     return await pickImage();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.GET_IMAGE_INFO, async (_event, filePath: string) => {
+    return await getImageInfo(filePath);
   });
 
   ipcMain.handle(IPC_CHANNELS.RENAME_FILE, async (_event, oldPath: string, newPath: string) => {

--- a/src/main/services/flac/image.ts
+++ b/src/main/services/flac/image.ts
@@ -26,6 +26,18 @@ export const extractEmbeddedImage = async (
 };
 
 /**
+ * 指定されたパスの画像ファイルから Picture オブジェクトを生成して返します。
+ * @param filePath 画像ファイルの絶対パス
+ */
+export const getImageInfo = async (filePath: string): Promise<TagResult<Picture>> => {
+  return success({
+    format: getMimeTypeFromPath(filePath),
+    sourcePath: filePath,
+    hash: computeMd5(await readFile(filePath))
+  });
+};
+
+/**
  * 画像ファイル選択ダイアログを表示し、選択された画像のパス情報を返します。
  * @returns 選択された画像のパス情報。キャンセルされた場合は Result(null)。
  */
@@ -36,9 +48,5 @@ export const pickImage = async (): Promise<TagResult<Picture | null>> => {
     return success(null);
   }
 
-  return success({
-    format: getMimeTypeFromPath(filePath),
-    sourcePath: filePath,
-    hash: computeMd5(await readFile(filePath))
-  });
+  return await getImageInfo(filePath);
 };

--- a/src/main/services/platform/dialog.ts
+++ b/src/main/services/platform/dialog.ts
@@ -1,3 +1,4 @@
+import { SUPPORTED_IMAGE_EXTENSIONS } from '@domain/file-extensions';
 import { dialog, OpenDialogOptions } from 'electron';
 
 /**
@@ -22,7 +23,12 @@ export const pickImageFile = async (
 ): Promise<string | null> => {
   const result = await dialog.showOpenDialog({
     title: 'Select Artwork',
-    filters: [{ name: 'Images', extensions: ['jpg', 'jpeg', 'png', 'webp'] }],
+    filters: [
+      {
+        name: 'Images',
+        extensions: SUPPORTED_IMAGE_EXTENSIONS.map((ext) => ext.replace(/^\./, ''))
+      }
+    ],
     properties: ['openFile'],
     ...options
   });

--- a/src/main/utils/file-utils.ts
+++ b/src/main/utils/file-utils.ts
@@ -1,7 +1,6 @@
+import { SUPPORTED_AUDIO_EXTENSIONS } from '@domain/file-extensions';
 import { basename, extname } from 'node:path';
 import fs from 'node:fs/promises';
-
-const SUPPORTED_EXTENSIONS = ['.flac'];
 
 /**
  * 指定されたパスが隠しファイル（ドットで始まる）かどうかを判定します。
@@ -14,7 +13,7 @@ export const isHiddenPath = (path: string): boolean => {
  * 指定されたパスがサポートされている形式（現在は FLAC）かどうかを判定します。
  */
 export const isSupportedAudioFile = (path: string): boolean => {
-  return SUPPORTED_EXTENSIONS.includes(extname(path).toLowerCase());
+  return SUPPORTED_AUDIO_EXTENSIONS.includes(extname(path).toLowerCase());
 };
 
 /**

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -34,6 +34,11 @@ export const api: IpcApi = {
    */
   pickImage: () => ipcRenderer.invoke(IPC_CHANNELS.PICK_IMAGE),
   /**
+   * 指定したパスの画像情報を取得します。
+   * @param path 画像ファイルの絶対パス
+   */
+  getImageInfo: (path: string) => ipcRenderer.invoke(IPC_CHANNELS.GET_IMAGE_INFO, path),
+  /**
    * ファイルをリネーム（移動）します。
    * @param oldPath 現在のパス
    * @param newPath 新しいパス

--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -1,26 +1,22 @@
 <script lang="ts">
-  import DropZone from './components/DropZone.svelte';
   import Inspector from './components/Inspector.svelte';
   import StatusBar from './components/StatusBar.svelte';
   import Toolbar from './components/Toolbar.svelte';
   import TrackGrid from './components/TrackGrid.svelte';
   import KeyboardShortcuts from './components/KeyboardShortcuts.svelte';
-  import { tagActions } from './services/tag-actions';
 </script>
 
 <KeyboardShortcuts />
 
-<DropZone onDrop={(paths) => tagActions.loadFromPaths(paths)}>
-  <div class="app-container" role="region" aria-label="Application container">
-    <section class="main-content">
-      <Toolbar />
-      <TrackGrid />
-      <StatusBar />
-    </section>
+<div class="app-container" role="region" aria-label="Application container">
+  <section class="main-content">
+    <Toolbar />
+    <TrackGrid />
+    <StatusBar />
+  </section>
 
-    <Inspector />
-  </div>
-</DropZone>
+  <Inspector />
+</div>
 
 <style>
   .app-container {

--- a/src/renderer/src/components/DropZone.svelte
+++ b/src/renderer/src/components/DropZone.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
-  import { FolderOpen } from 'lucide-svelte';
   import type { Snippet } from 'svelte';
-  import { UI_TOKENS } from '../constants/design-system';
   import { uiState } from '../stores/ui-state.svelte';
-  import { getAllPathsFromDropEvent } from '../utils/drag-drop';
+  import { getAllPathsFromDropEvent } from '../infrastructure/file-drop-adapter';
+  import { filterByExtensions } from '@shared/utils/file-filter';
 
   interface Props {
     children: Snippet;
+    overlay: Snippet;
     onDrop: (paths: string[]) => void;
+    accept?: readonly string[];
   }
 
-  let { children, onDrop }: Props = $props();
+  let { children, overlay, onDrop, accept = [] }: Props = $props();
 
   let isDragging = $state(false);
 
@@ -23,7 +24,6 @@
   const handleDragLeave = (e: DragEvent): void => {
     e.preventDefault();
     e.stopPropagation();
-    // 子要素への移動ではリセットしない (本当のコンテナ外脱出のみ判定)
     const container = e.currentTarget as HTMLElement;
     const related = e.relatedTarget as Node | null;
     if (!related || !container.contains(related)) {
@@ -40,7 +40,12 @@
       return;
     }
 
-    const paths = getAllPathsFromDropEvent(e);
+    let paths = getAllPathsFromDropEvent(e);
+
+    if (accept.length > 0) {
+      paths = filterByExtensions(paths, accept);
+    }
+
     if (paths.length > 0) {
       onDrop(paths);
     }
@@ -59,13 +64,7 @@
 
   {#if isDragging}
     <div class="drop-overlay">
-      <div class="drop-content">
-        <div class="icon-wrapper">
-          <FolderOpen size={UI_TOKENS.icons.sizeLarge} strokeWidth={1} />
-        </div>
-        <h2>Drop to scan FLAC files</h2>
-        <p>Release to open</p>
-      </div>
+      {@render overlay()}
     </div>
   {/if}
 </div>
@@ -103,33 +102,5 @@
       opacity: 1;
       transform: scale(1);
     }
-  }
-
-  .drop-content {
-    text-align: center;
-    color: var(--accent-primary);
-  }
-
-  .drop-content h2 {
-    font-size: 1.5rem;
-    margin: 1rem 0 0.5rem;
-    font-weight: 600;
-  }
-
-  .drop-content p {
-    color: var(--text-muted);
-    font-size: 1rem;
-  }
-
-  .icon-wrapper {
-    background: var(--accent-primary-dim);
-    color: var(--accent-primary);
-    width: 96px;
-    height: 96px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin: 0 auto;
   }
 </style>

--- a/src/renderer/src/components/DropZoneOverlay.svelte
+++ b/src/renderer/src/components/DropZoneOverlay.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { UI_TOKENS } from '@renderer/constants/design-system';
+  import { type IconProps } from '@lucide/svelte';
+  import type { Component } from 'svelte';
+
+  interface Props {
+    icon: Component<IconProps>;
+    title: string;
+    sub?: string;
+  }
+
+  let { icon: ICON, title, sub }: Props = $props();
+</script>
+
+<div class="drop-content">
+  <div class="icon-wrapper">
+    <ICON size={UI_TOKENS.icons.sizeLarge} strokeWidth={1} />
+  </div>
+  <h2>{title}</h2>
+  {#if sub}
+    <p>{sub}</p>
+  {/if}
+</div>
+
+<style>
+  .drop-content {
+    text-align: center;
+    color: var(--accent-primary);
+  }
+
+  .drop-content h2 {
+    font-size: 1.5rem;
+    margin: 1rem 0 0.5rem;
+    font-weight: 600;
+  }
+
+  .drop-content p {
+    color: var(--text-muted);
+    font-size: 1rem;
+  }
+
+  .icon-wrapper {
+    background: var(--accent-primary-dim);
+    color: var(--accent-primary);
+    width: 96px;
+    height: 96px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto;
+  }
+</style>

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { uiState } from '../stores/ui-state.svelte';
-  import { CircleAlert, TriangleAlert } from 'lucide-svelte';
+  import { CircleAlert, TriangleAlert } from '@lucide/svelte';
   import { UI_TOKENS } from '@renderer/constants/design-system';
 </script>
 

--- a/src/renderer/src/components/Toolbar.svelte
+++ b/src/renderer/src/components/Toolbar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { UI_TOKENS } from '@renderer/constants/design-system';
-  import { Disc3, FilePen, FolderOpen, RotateCcw, Save, Tag } from 'lucide-svelte';
+  import { Disc3, FilePen, FolderOpen, RotateCcw, Save, Tag } from '@lucide/svelte';
   import { tagActions } from '../services/tag-actions';
   import { fileActions } from '../services/file-actions';
   import { trackStore } from '../stores/track-store.svelte';

--- a/src/renderer/src/components/TrackGrid.svelte
+++ b/src/renderer/src/components/TrackGrid.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
+  import { SUPPORTED_AUDIO_EXTENSIONS } from '@domain/file-extensions';
+  import { FolderOpen } from '@lucide/svelte';
+  import { tagActions } from '../services/tag-actions';
   import { selectionState } from '../stores/selection-state.svelte';
   import { TrackRecord } from '../stores/track-record.svelte';
   import { trackStore } from '../stores/track-store.svelte';
+  import DropZone from './DropZone.svelte';
+  import DropZoneOverlay from './DropZoneOverlay.svelte';
 
   const rowElements: HTMLElement[] = [];
 
@@ -29,43 +34,48 @@
   };
 </script>
 
-<div class="grid-wrapper">
-  {#if trackStore.tracks.length > 0}
-    <table class="data-grid">
-      <thead>
-        <tr>
-          <th class="col-indicator"></th>
-          <th class="col-track">#</th>
-          <th>Title</th>
-          <th>Artist</th>
-          <th>Album</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each trackStore.tracks as track, i (track)}
-          <tr
-            bind:this={rowElements[i]}
-            class="track-row"
-            class:selected={selectionState.has(track)}
-            class:modified={track.isModified}
-            onclick={(e) => handleRowClick(e, i, track)}
-            aria-selected={selectionState.has(track)}
-          >
-            <td class="indicator-cell"></td>
-            <td class="track-cell">{track.metadata.trackNumber ?? ''}</td>
-            <td>{track.metadata.title}</td>
-            <td>{track.metadata.artist}</td>
-            <td>{track.metadata.album}</td>
+<DropZone onDrop={(paths) => tagActions.loadFromPaths(paths)} accept={SUPPORTED_AUDIO_EXTENSIONS}>
+  {#snippet overlay()}
+    <DropZoneOverlay icon={FolderOpen} title="Drop to scan FLAC files" sub="Release to open" />
+  {/snippet}
+  <div class="grid-wrapper">
+    {#if trackStore.tracks.length > 0}
+      <table class="data-grid">
+        <thead>
+          <tr>
+            <th class="col-indicator"></th>
+            <th class="col-track">#</th>
+            <th>Title</th>
+            <th>Artist</th>
+            <th>Album</th>
           </tr>
-        {/each}
-      </tbody>
-    </table>
-  {:else}
-    <div class="empty-state">
-      <p>Click "Open Folder" to start tagging your FLAC files.</p>
-    </div>
-  {/if}
-</div>
+        </thead>
+        <tbody>
+          {#each trackStore.tracks as track, i (track)}
+            <tr
+              bind:this={rowElements[i]}
+              class="track-row"
+              class:selected={selectionState.has(track)}
+              class:modified={track.isModified}
+              onclick={(e) => handleRowClick(e, i, track)}
+              aria-selected={selectionState.has(track)}
+            >
+              <td class="indicator-cell"></td>
+              <td class="track-cell">{track.metadata.trackNumber ?? ''}</td>
+              <td>{track.metadata.title}</td>
+              <td>{track.metadata.artist}</td>
+              <td>{track.metadata.album}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {:else}
+      <div class="empty-state">
+        <p>Click "Open Folder" to start tagging your FLAC files.</p>
+      </div>
+    {/if}
+  </div>
+</DropZone>
 
 <style>
   .grid-wrapper {

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { UI_TOKENS } from '@renderer/constants/design-system';
-  import { Music, X } from 'lucide-svelte';
-  import { trackStore } from '../../stores/track-store.svelte';
+  import { Image as ImageIcon, Music, X } from '@lucide/svelte';
+  import { SUPPORTED_IMAGE_EXTENSIONS } from '@domain/file-extensions';
   import { tagActions } from '../../services/tag-actions';
+  import { trackStore } from '../../stores/track-store.svelte';
+  import DropZone from '../DropZone.svelte';
+  import DropZoneOverlay from '../DropZoneOverlay.svelte';
 
   let imageLoadError = $state(false);
 
@@ -23,47 +26,55 @@
   };
 </script>
 
-<div
-  class="artwork-section"
-  onclick={() => tagActions.pickAndApplyPicture()}
-  onkeydown={(e) => e.key === 'Enter' && tagActions.pickAndApplyPicture()}
-  role="button"
-  tabindex="0"
-  title="Click to change artwork"
+<DropZone
+  accept={SUPPORTED_IMAGE_EXTENSIONS}
+  onDrop={(paths) => tagActions.applyPictureFromPath(paths[0])}
 >
-  {#if trackStore.commonImageUrl}
-    <img
-      src={trackStore.commonImageUrl}
-      alt="Cover Art"
-      class="cover-art"
-      class:hidden={imageLoadError}
-      onerror={() => (imageLoadError = true)}
-      onload={() => (imageLoadError = false)}
-    />
-    {#if !imageLoadError}
-      <button class="remove-artwork" onclick={handleRemoveArtwork} title="Remove Artwork">
-        <X size={UI_TOKENS.icons.size} />
-      </button>
+  {#snippet overlay()}
+    <DropZoneOverlay icon={ImageIcon} title="Drop to set Artwork" sub="Apply to selected tracks" />
+  {/snippet}
+  <div
+    class="artwork-section"
+    onclick={() => tagActions.pickAndApplyPicture()}
+    onkeydown={(e) => e.key === 'Enter' && tagActions.pickAndApplyPicture()}
+    role="button"
+    tabindex="0"
+    title="Click to change artwork"
+  >
+    {#if trackStore.commonImageUrl}
+      <img
+        src={trackStore.commonImageUrl}
+        alt="Cover Art"
+        class="cover-art"
+        class:hidden={imageLoadError}
+        onerror={() => (imageLoadError = true)}
+        onload={() => (imageLoadError = false)}
+      />
+      {#if !imageLoadError}
+        <button class="remove-artwork" onclick={handleRemoveArtwork} title="Remove Artwork">
+          <X size={UI_TOKENS.icons.size} />
+        </button>
+      {/if}
     {/if}
-  {/if}
 
-  {#if !trackStore.commonImageUrl || imageLoadError}
-    <div
-      class="cover-placeholder"
-      class:error={imageLoadError}
-      class:mixed={trackStore.commonMetadata?.picture.type === 'divergent'}
-    >
-      <div class="icon-wrapper">
-        <Music size={UI_TOKENS.icons.sizeLarge} strokeWidth={UI_TOKENS.icons.strokeWidth} />
+    {#if !trackStore.commonImageUrl || imageLoadError}
+      <div
+        class="cover-placeholder"
+        class:error={imageLoadError}
+        class:mixed={trackStore.commonMetadata?.picture.type === 'divergent'}
+      >
+        <div class="icon-wrapper">
+          <Music size={UI_TOKENS.icons.sizeLarge} strokeWidth={UI_TOKENS.icons.strokeWidth} />
+        </div>
+        <span class="text">{getPlaceholderText()}</span>
       </div>
-      <span class="text">{getPlaceholderText()}</span>
-    </div>
-  {/if}
+    {/if}
 
-  <div class="art-overlay">
-    <span>Change Artwork</span>
+    <div class="art-overlay">
+      <span>Change Artwork</span>
+    </div>
   </div>
-</div>
+</DropZone>
 
 <style>
   .artwork-section {

--- a/src/renderer/src/components/inspector/BadgeField.svelte
+++ b/src/renderer/src/components/inspector/BadgeField.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { X } from 'lucide-svelte';
+  import { X } from '@lucide/svelte';
   import { UI_TOKENS } from '../../constants/design-system';
 
   interface Props {

--- a/src/renderer/src/components/inspector/MultiValueField.svelte
+++ b/src/renderer/src/components/inspector/MultiValueField.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Plus, X } from 'lucide-svelte';
+  import { Plus, X } from '@lucide/svelte';
   import type { Snippet } from 'svelte';
   import { UI_TOKENS } from '../../constants/design-system';
 

--- a/src/renderer/src/infrastructure/file-drop-adapter.test.ts
+++ b/src/renderer/src/infrastructure/file-drop-adapter.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getAllPathsFromDropEvent, type DropEventLike } from './drag-drop';
+import { getAllPathsFromDropEvent, type DropEventLike } from './file-drop-adapter';
 
 describe('getAllPathsFromDropEvent', () => {
   const mockGetPathForFile = vi.fn();

--- a/src/renderer/src/infrastructure/file-drop-adapter.ts
+++ b/src/renderer/src/infrastructure/file-drop-adapter.ts
@@ -1,7 +1,5 @@
 /**
  * ドラッグ＆ドロップイベントから必要なプロパティだけを定義。
- * e.dataTransfer.files は FileList ですが、これは ArrayLike<File> を満たすため
- * テストなどで File[] を渡すことも可能です。
  */
 export interface DropEventLike {
   readonly dataTransfer: {
@@ -11,7 +9,7 @@ export interface DropEventLike {
 
 /**
  * ドラッグ＆ドロップイベントから、ドロップされたすべての項目の OS 絶対パスを抽出します。
- * Electron v28+ では File.path が廃止されたため、webUtils.getPathForFile を使用します。
+ * Electron特有の webUtils.getPathForFile (window.api経由) を使用します。
  */
 export const getAllPathsFromDropEvent = (e: DropEventLike): string[] => {
   const files = e.dataTransfer?.files;

--- a/src/renderer/src/infrastructure/file-repository.ts
+++ b/src/renderer/src/infrastructure/file-repository.ts
@@ -1,0 +1,12 @@
+import type { TagResult } from '@domain/flac/types';
+
+/**
+ * 物理的なファイル操作（リネームなど）を担当するリポジトリ。
+ */
+const renameFile = async (oldPath: string, newPath: string): Promise<TagResult<void>> => {
+  return await window.api.renameFile(oldPath, newPath);
+};
+
+export const fileRepository = {
+  renameFile
+} as const;

--- a/src/renderer/src/infrastructure/path-adapter.ts
+++ b/src/renderer/src/infrastructure/path-adapter.ts
@@ -1,4 +1,8 @@
 /**
+ * Electron/Node.jsのパス操作APIをRendererプロセスから利用するためのアダプター。
+ */
+
+/**
  * フルパスからディレクトリ名を抽出します。
  * @param path 対象のフルパス
  * @returns ディレクトリパス

--- a/src/renderer/src/infrastructure/tag-repository.ts
+++ b/src/renderer/src/infrastructure/tag-repository.ts
@@ -2,34 +2,12 @@ import { success } from '@domain/common/result';
 import type { FlacTrack, Picture, TagResult } from '@domain/flac/types';
 
 /**
- * メインプロセス（Electron IPC）との通信を担当するサービス。
+ * 楽曲データ（FLACタグ）の物理的な読み書きを担当するリポジトリ。
+ * Electron IPC経由でメインプロセスのサービスと通信します。
  */
 
-const loadSingleTrack = async (path: string): Promise<TagResult<FlacTrack>> => {
+const readMetadata = async (path: string): Promise<TagResult<FlacTrack>> => {
   return await window.api.readMetadata(path);
-};
-
-const loadTracksFromFiles = async (filePaths: string[]): Promise<FlacTrack[]> => {
-  const loadPromises = filePaths.map((path) => loadSingleTrack(path));
-  const results = await Promise.all(loadPromises);
-
-  const tracks: FlacTrack[] = [];
-  for (const result of results) {
-    if (result.type === 'success') {
-      tracks.push(result.value);
-    }
-  }
-  return tracks;
-};
-
-const scanAndLoadTracks = async (): Promise<
-  TagResult<{ tracks: FlacTrack[]; isLimited: boolean } | null>
-> => {
-  const dirPath = await window.api.selectDirectory();
-  if (!dirPath) {
-    return success(null);
-  }
-  return await loadTracksFromPaths([dirPath]);
 };
 
 const loadTracksFromPaths = async (
@@ -41,13 +19,27 @@ const loadTracksFromPaths = async (
   }
 
   const { paths: filePaths, isLimited } = scanResult.value;
-  const tracks = await loadTracksFromFiles(filePaths);
+  const loadPromises = filePaths.map((path) => readMetadata(path));
+  const results = await Promise.all(loadPromises);
+
+  const tracks: FlacTrack[] = [];
+  for (const result of results) {
+    if (result.type === 'success') {
+      tracks.push(result.value);
+    }
+  }
 
   return success({ tracks, isLimited });
 };
 
-const readMetadata = async (path: string): Promise<TagResult<FlacTrack>> => {
-  return await window.api.readMetadata(path);
+const scanAndLoadTracks = async (): Promise<
+  TagResult<{ tracks: FlacTrack[]; isLimited: boolean } | null>
+> => {
+  const dirPath = await window.api.selectDirectory();
+  if (!dirPath) {
+    return success(null);
+  }
+  return await loadTracksFromPaths([dirPath]);
 };
 
 const saveTracks = async (tracks: FlacTrack[]): Promise<TagResult<void>> => {
@@ -64,10 +56,15 @@ const pickImage = async (): Promise<TagResult<Picture | null>> => {
   return await window.api.pickImage();
 };
 
-export const tagIoService = {
+const getImageInfo = async (path: string): Promise<TagResult<Picture>> => {
+  return await window.api.getImageInfo(path);
+};
+
+export const tagRepository = {
   scanAndLoadTracks,
   loadTracksFromPaths,
   readMetadata,
   saveTracks,
-  pickImage
+  pickImage,
+  getImageInfo
 } as const;

--- a/src/renderer/src/services/file-actions.ts
+++ b/src/renderer/src/services/file-actions.ts
@@ -3,8 +3,9 @@ import { TrackRecord } from '../stores/track-record.svelte';
 import { trackStore } from '../stores/track-store.svelte';
 import { uiState } from '../stores/ui-state.svelte';
 import { selectionState } from '../stores/selection-state.svelte';
-import { tagIoService } from './tag-io-service';
-import { getDirectoryName, joinPath } from '../utils/path';
+import { tagRepository } from '../infrastructure/tag-repository';
+import { fileRepository } from '../infrastructure/file-repository';
+import { getDirectoryName, joinPath } from '../infrastructure/path-adapter';
 
 /**
  * 選択中のファイルをメタデータに基づいてリネームします。
@@ -74,14 +75,14 @@ const renameTrack = async (track: TrackRecord): Promise<TrackRecord | null> => {
   }
 
   // 3. 物理的なリネーム実行
-  const result = await window.api.renameFile(track.path, newPath);
+  const result = await fileRepository.renameFile(track.path, newPath);
   if (result.type === 'error') {
     uiState.setError(result);
     return null;
   }
 
   // 3. 成功時: 再読み込みして新しい不変インスタンスを作成
-  const reloadResult = await tagIoService.readMetadata(newPath);
+  const reloadResult = await tagRepository.readMetadata(newPath);
   if (reloadResult.type === 'error') {
     uiState.setError(reloadResult);
     return null;

--- a/src/renderer/src/services/tag-actions.ts
+++ b/src/renderer/src/services/tag-actions.ts
@@ -4,7 +4,7 @@ import { trackStore } from '../stores/track-store.svelte';
 import { TrackRecord } from '../stores/track-record.svelte';
 import { uiState } from '../stores/ui-state.svelte';
 import { tagEditor } from './tag-editor';
-import { tagIoService } from './tag-io-service';
+import { tagRepository } from '../infrastructure/tag-repository';
 
 /**
  * スキャン処理の共通的なフローを制御するヘルパー関数。
@@ -36,14 +36,14 @@ const handleScanOperation = async (
  * フォルダ選択ダイアログを開き、中のFLACファイルをスキャンします。
  */
 const openAndScanDirectory = async (): Promise<void> => {
-  await handleScanOperation(() => tagIoService.scanAndLoadTracks());
+  await handleScanOperation(() => tagRepository.scanAndLoadTracks());
 };
 
 /**
  * 指定された複数のパスを直接スキャンして読み込みます。
  */
 const loadFromPaths = async (targetPaths: string[]): Promise<void> => {
-  await handleScanOperation(() => tagIoService.loadTracksFromPaths(targetPaths));
+  await handleScanOperation(() => tagRepository.loadTracksFromPaths(targetPaths));
 };
 
 /**
@@ -83,7 +83,20 @@ const removeSelectedMultiFieldValue = (key: EditableMultiKey, value: string): vo
  */
 const pickAndApplyPicture = async (): Promise<void> => {
   uiState.clearError();
-  const result = await tagIoService.pickImage();
+  const result = await tagRepository.pickImage();
+  if (result.type === 'error') {
+    uiState.setError(result);
+  } else if (result.value) {
+    tagEditor.applyPicture(trackStore.selectedTracks, result.value);
+  }
+};
+
+/**
+ * 指定されたパスの画像を読み込み、選択中のトラックに適用します（ドラッグ＆ドロップ用）。
+ */
+const applyPictureFromPath = async (path: string): Promise<void> => {
+  uiState.clearError();
+  const result = await tagRepository.getImageInfo(path);
   if (result.type === 'error') {
     uiState.setError(result);
   } else if (result.value) {
@@ -119,7 +132,7 @@ const revertSelected = async (): Promise<void> => {
 
   try {
     for (const track of modifiedSelected) {
-      const result = await tagIoService.readMetadata(track.path);
+      const result = await tagRepository.readMetadata(track.path);
       if (result.type === 'error') {
         uiState.setError(result);
         break;
@@ -149,7 +162,7 @@ const saveAllModified = async (): Promise<void> => {
   try {
     // インフラ層に渡すためにドメインモデルの配列に整形
     const rawData = modified.map((t) => t.toFlacTrack());
-    const result = await tagIoService.saveTracks(rawData);
+    const result = await tagRepository.saveTracks(rawData);
 
     if (result.type === 'error') {
       uiState.setError(result);
@@ -176,6 +189,7 @@ export const tagActions = {
   removeSelectedMultiFieldValue,
   applySelectedMultiFieldChange,
   pickAndApplyPicture,
+  applyPictureFromPath,
   removeArtwork,
   applyAutoNumbering,
   revertSelected,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -19,6 +19,8 @@ export const IPC_CHANNELS = {
   SCAN_DIRECTORY: 'flac:scan-directory',
   /** 画像ファイルを選択して読み込み */
   PICK_IMAGE: 'flac:pick-image',
+  /** 指定したパスの画像情報を取得 */
+  GET_IMAGE_INFO: 'flac:get-image-info',
   /** ファイルのリネーム */
   RENAME_FILE: 'flac:rename-file'
 } as const;
@@ -39,6 +41,8 @@ export interface IpcApi {
   scanDirectory: (targetPaths: string[]) => Promise<TagResult<ScanResult>>;
   /** 画像ファイルを選択し、メタデータ用の Picture オブジェクトを返します */
   pickImage: () => Promise<TagResult<Picture | null>>;
+  /** 指定したパスの画像ファイルから Picture オブジェクトを生成して返します */
+  getImageInfo: (filePath: string) => Promise<TagResult<Picture>>;
   /** ファイルをリネーム（移動）します */
   renameFile: (oldPath: string, newPath: string) => Promise<TagResult<void>>;
   /** File オブジェクトから OS 上のファイルシステムパスを取得します */

--- a/src/shared/utils/file-filter.ts
+++ b/src/shared/utils/file-filter.ts
@@ -1,0 +1,19 @@
+/**
+ * ファイルパスの配列から、指定された拡張子を持つもののみを抽出します。
+ * @param paths ファイルパスの配列
+ * @param extensions 許可する拡張子の配列（例: ['.jpg', '.png']）
+ * @returns フィルタリングされたパスの配列
+ */
+export const filterByExtensions = (paths: string[], extensions: readonly string[]): string[] => {
+  return paths.filter((path) => hasExtension(path, extensions));
+};
+
+/**
+ * 指定されたパスが、指定された拡張子のいずれかを持つか判定します。
+ * @param path ファイルパス
+ * @param extensions 許可する拡張子の配列
+ */
+export const hasExtension = (path: string, extensions: readonly string[]): boolean => {
+  const lowerPath = path.toLowerCase();
+  return extensions.some((ext) => lowerPath.endsWith(ext.toLowerCase()));
+};


### PR DESCRIPTION
Issue #26 の対応です。
現状ウィンドウ全体で FLAC ファイルのドロップを受け付けていたものを改修し、Grid（FLAC用）とインスペクター（画像用）で個別にドロップを受け付けるように分離しました。

併せて、Svelte 5 への適合を目的としたアイコンライブラリ（@lucide/svelte）への移行と、拡張子管理の SSOT 化、およびインフラ層の整理を実施しています。

### 主な変更点
- `src/renderer/src/components/DropZone.svelte`: 特定の拡張子でフィルタリング可能に拡張。
- `TrackGrid.svelte`: 音声ファイルのみを受け付けるドロップゾーンを配置。
- `ArtworkSection.svelte`: 画像ファイルのみを受け付けるドロップゾーンを配置。
- `src/domain/file-extensions.ts`: サポート拡張子の定義を一元化。
- `src/renderer/src/infrastructure/`: リポジトリパターンを導入し、データアクセスを整理。
- `@lucide/svelte` への移行による型安全なアイコン利用。