### PR TITLE
fix: アートワーク表示不正およびドロップ領域の消失を修正 (#43)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/src/main/protocols/image-protocol.ts
+++ b/src/main/protocols/image-protocol.ts
@@ -1,5 +1,4 @@
 import { HTTP_STATUS } from '@shared/http-status';
-import { IMAGE_PROTOCOL_SCHEME } from '@shared/ipc';
 import { net } from 'electron';
 import path from 'node:path';
 import { pathToFileURL } from 'url';
@@ -39,22 +38,26 @@ export const handleImageRequest = async (request: Request): Promise<Response> =>
  * @throws ProtocolError パスが無効な場合
  */
 const parseProtocolUrl = (requestUrl: string): string => {
-  // 1. スキーム部分 (flac-image://) を正規表現で取り除く
-  const rawPath = requestUrl.replace(new RegExp(`^${IMAGE_PROTOCOL_SCHEME}://`), '');
+  try {
+    const url = new URL(requestUrl);
+    // デコードされたパスを取得（ホスト名部分とパス部分を結合）
+    // protocol.handleに渡されるリクエストURLは正規化されているが、
+    // URLオブジェクトを通すことでクエリパラメータ等を安全に除外できる。
+    const decodedPath = decodeURIComponent(url.pathname);
+    // Windows環境や絶対パスの扱いを共通化するため正規化
+    const filePath = path.resolve('/', decodedPath);
 
-  // 2. デコードして元のパス文字列を復元
-  const decoded = decodeURIComponent(rawPath);
+    if (!filePath || filePath === '/') {
+      throw new ProtocolError('File path is required', HTTP_STATUS.BAD_REQUEST);
+    }
 
-  // 3. 絶対パスとして正規化
-  // 先頭のスラッシュが欠落していても path.resolve('/') が補完し、
-  // Windows のドライブレターなども正しくハンドルされる。
-  const filePath = path.resolve('/', decoded);
-
-  if (!filePath || filePath === '/') {
-    throw new ProtocolError('File path is required', HTTP_STATUS.BAD_REQUEST);
+    return filePath;
+  } catch (error) {
+    if (error instanceof ProtocolError) {
+      throw error;
+    }
+    throw new ProtocolError('Invalid URL format', HTTP_STATUS.BAD_REQUEST);
   }
-
-  return filePath;
 };
 
 /**

--- a/src/main/protocols/image-protocol.ts
+++ b/src/main/protocols/image-protocol.ts
@@ -45,12 +45,12 @@ const parseProtocolUrl = (requestUrl: string): string => {
     throw new ProtocolError('Invalid URL format', HTTP_STATUS.BAD_REQUEST);
   }
 
-  // デコードされたパスを取得（ホスト名部分とパス部分を結合）
-  // protocol.handleに渡されるリクエストURLは正規化されているが、
-  // URLオブジェクトを通すことでクエリパラメータ等を安全に除外できる。
-  const decodedPath = decodeURIComponent(url.pathname);
+  // ホスト部分（もしあれば）とパス部分を結合して絶対パスを復元する
+  // (flac-image://host/path -> host/path, flac-image:///path -> /path)
+  const fullPath = url.host + url.pathname;
+  const decodedPath = decodeURIComponent(fullPath);
 
-  // Windows環境や絶対パスの扱いを共通化するため正規化
+  // 絶対パスとして正規化
   const filePath = path.resolve('/', decodedPath);
 
   if (!filePath || filePath === '/') {

--- a/src/main/protocols/image-protocol.ts
+++ b/src/main/protocols/image-protocol.ts
@@ -38,26 +38,26 @@ export const handleImageRequest = async (request: Request): Promise<Response> =>
  * @throws ProtocolError パスが無効な場合
  */
 const parseProtocolUrl = (requestUrl: string): string => {
+  let url: URL;
   try {
-    const url = new URL(requestUrl);
-    // デコードされたパスを取得（ホスト名部分とパス部分を結合）
-    // protocol.handleに渡されるリクエストURLは正規化されているが、
-    // URLオブジェクトを通すことでクエリパラメータ等を安全に除外できる。
-    const decodedPath = decodeURIComponent(url.pathname);
-    // Windows環境や絶対パスの扱いを共通化するため正規化
-    const filePath = path.resolve('/', decodedPath);
-
-    if (!filePath || filePath === '/') {
-      throw new ProtocolError('File path is required', HTTP_STATUS.BAD_REQUEST);
-    }
-
-    return filePath;
-  } catch (error) {
-    if (error instanceof ProtocolError) {
-      throw error;
-    }
+    url = new URL(requestUrl);
+  } catch {
     throw new ProtocolError('Invalid URL format', HTTP_STATUS.BAD_REQUEST);
   }
+
+  // デコードされたパスを取得（ホスト名部分とパス部分を結合）
+  // protocol.handleに渡されるリクエストURLは正規化されているが、
+  // URLオブジェクトを通すことでクエリパラメータ等を安全に除外できる。
+  const decodedPath = decodeURIComponent(url.pathname);
+
+  // Windows環境や絶対パスの扱いを共通化するため正規化
+  const filePath = path.resolve('/', decodedPath);
+
+  if (!filePath || filePath === '/') {
+    throw new ProtocolError('File path is required', HTTP_STATUS.BAD_REQUEST);
+  }
+
+  return filePath;
 };
 
 /**

--- a/src/renderer/src/components/DropZone.svelte
+++ b/src/renderer/src/components/DropZone.svelte
@@ -71,10 +71,8 @@
 
 <style>
   .drop-zone-container {
-    width: 100%;
-    height: 100%;
     position: relative;
-    overflow: hidden;
+    width: 100%;
   }
 
   .drop-overlay {

--- a/src/renderer/src/components/DropZone.svelte
+++ b/src/renderer/src/components/DropZone.svelte
@@ -71,8 +71,10 @@
 
 <style>
   .drop-zone-container {
-    position: relative;
     width: 100%;
+    position: relative;
+    display: flex;
+    flex-direction: column;
   }
 
   .drop-overlay {

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -96,11 +96,19 @@
     background-color: var(--bg-hover);
     border: 1px solid var(--border-primary);
     padding: 1px;
+    display: grid;
+    place-items: center;
+  }
+
+  .cover-art,
+  .cover-placeholder,
+  .art-overlay {
+    grid-area: 1 / 1;
+    width: 100%;
+    height: 100%;
   }
 
   .cover-art {
-    width: 100%;
-    height: 100%;
     object-fit: cover;
     transition: transform 0.3s ease;
   }
@@ -110,8 +118,6 @@
   }
 
   .art-overlay {
-    position: absolute;
-    inset: 0;
     background: rgba(0, 0, 0, 0.4);
     display: flex;
     align-items: center;
@@ -119,6 +125,7 @@
     opacity: 0;
     transition: opacity 0.2s;
     backdrop-filter: blur(2px);
+    z-index: 5;
   }
 
   .artwork-section:hover .art-overlay {
@@ -164,8 +171,6 @@
   }
 
   .cover-placeholder {
-    width: 100%;
-    height: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -9,6 +9,13 @@
 
   let imageLoadError = $state(false);
 
+  // URLが変わるたびにエラー状態をリセットする
+  $effect(() => {
+    if (trackStore.commonImageUrl) {
+      imageLoadError = false;
+    }
+  });
+
   const handleRemoveArtwork = (e: MouseEvent): void => {
     e.stopPropagation();
     tagActions.removeArtwork();

--- a/src/renderer/src/utils/image.ts
+++ b/src/renderer/src/utils/image.ts
@@ -17,5 +17,6 @@ export const createImageUrl = (picture?: Picture | null): string | null => {
   }
   // 絶対パスを（大文字小文字を含め）そのまま維持できるよう、
   // 3本スラッシュ形式 (flac-image:///path/to/file) の URL を生成します。
-  return `${IMAGE_PROTOCOL_SCHEME}://${picture.sourcePath}`;
+  // 特殊文字（#や?など）をエスケープするため encodeURI を使用します。
+  return `${IMAGE_PROTOCOL_SCHEME}://${encodeURI(picture.sourcePath)}`;
 };


### PR DESCRIPTION
GitHub Issue #43 「アートワーク表示不正」に対応しました。

### 修正内容
1. **アートワーク表示領域の消失修正**: `DropZone.svelte` の `height: 100%` 指定を削除し、Inspector内でのレイアウト崩れ（高さが0になる問題）を解消しました。
2. **画像読み込みエラー状態の管理改善**: `ArtworkSection.svelte` にて、別トラックへの切り替え時に画像読み込みエラー状態が正しくリセットされるよう修正しました。
3. **プロトコルURLの堅牢化**:
    - メインプロセス (`image-protocol.ts`) でのパス抽出処理に `URL` オブジェクトを使用し、クエリパラメータ等を安全に除外できるよう改善。
    - レンダラープロセス (`image.ts`) でパスを `encodeURI` し、特殊文字を含むパスでも画像が表示されるよう修正。

### 検証内容
- `pnpm format`, `pnpm lint`, `pnpm test`, `pnpm build` の全てが正常終了することを確認済み。
- （ローカル環境での目視確認を想定したロジックの修正）

### バージョン更新
- `v0.13.1` に更新しました。