### PR TITLE
feat: フォーカス中の要素にグローエフェクトを追加 (#50)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -32,5 +32,6 @@
     background-color: #1e1e1e;
     border-right: 1px solid #333;
     overflow: hidden;
+    min-height: 0;
   }
 </style>

--- a/src/renderer/src/components/TrackGrid.svelte
+++ b/src/renderer/src/components/TrackGrid.svelte
@@ -93,6 +93,7 @@
     overflow-y: auto;
     background-color: var(--bg-main);
     user-select: none;
+    min-height: 0;
   }
 
   .data-grid {

--- a/src/renderer/src/components/TrackGrid.svelte
+++ b/src/renderer/src/components/TrackGrid.svelte
@@ -221,9 +221,7 @@
 
   .empty-icon:focus-visible {
     border-color: var(--accent-primary);
-    box-shadow:
-      0 0 0 2px var(--accent-primary-dim),
-      0 0 15px var(--selection-glow);
+    box-shadow: var(--focus-ring), var(--focus-glow);
   }
 
   .empty-state p {

--- a/src/renderer/src/components/inspector/BadgeField.svelte
+++ b/src/renderer/src/components/inspector/BadgeField.svelte
@@ -87,6 +87,7 @@
   .badge-container:focus-within {
     border-color: var(--accent-primary);
     background-color: var(--bg-secondary);
+    box-shadow: var(--focus-ring), var(--focus-glow);
   }
 
   .badge-container.divergent {

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -38,12 +38,21 @@
   --radius-xl: 12px;
   --radius-2xl: 20px;
   --radius-full: 9999px;
-}
+ 
+   /* フォーカスエフェクト */
+   --focus-ring: 0 0 0 2px var(--accent-primary-dim);
+   --focus-glow: 0 0 8px var(--selection-glow);
+ }
 
 *,
 *::before,
 *::after {
   box-sizing: border-box;
+}
+
+:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring), var(--focus-glow);
 }
 
 body {
@@ -127,6 +136,7 @@ body {
 .field input:focus {
   border-color: var(--accent-primary);
   background-color: var(--bg-secondary);
+  box-shadow: var(--focus-ring), var(--focus-glow);
 }
 
 .field input.disabled {

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -41,7 +41,7 @@
 
   /* フォーカスエフェクト */
   --focus-ring: 0 0 0 2px var(--accent-primary-dim);
-  --focus-glow: 0 0 4px var(--selection-glow);
+  --focus-glow: 0 0 6px var(--selection-glow);
 }
 
 *,

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -41,7 +41,7 @@
 
   /* フォーカスエフェクト */
   --focus-ring: 0 0 0 2px var(--accent-primary-dim);
-  --focus-glow: 0 0 8px var(--selection-glow);
+  --focus-glow: 0 0 4px var(--selection-glow);
 }
 
 *,

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -38,11 +38,11 @@
   --radius-xl: 12px;
   --radius-2xl: 20px;
   --radius-full: 9999px;
- 
-   /* フォーカスエフェクト */
-   --focus-ring: 0 0 0 2px var(--accent-primary-dim);
-   --focus-glow: 0 0 8px var(--selection-glow);
- }
+
+  /* フォーカスエフェクト */
+  --focus-ring: 0 0 0 2px var(--accent-primary-dim);
+  --focus-glow: 0 0 8px var(--selection-glow);
+}
 
 *,
 *::before,


### PR DESCRIPTION
## 概要
GitHub Issue #50 に対処し、フォーカス中の要素に「光彩（グロー）エフェクト」を追加しました。
これにより、ユーザーが現在どの要素を操作しているかが視覚的に明確になり、アプリの質感が向上しました。

## 変更内容
- `index.css`:
    - `--focus-ring` および `--focus-glow` 変数を定義。
    - キーボード操作時の視認性を高めるため、グローバルな `:focus-visible` スタイルを追加。
    - `input` 要素のフォーカス時にアクセントカラーのグローが表示されるように更新。
- `BadgeField.svelte`: コンテナ全体のフォーカス（`focus-within`）時にグローを適用。
- `TrackGrid.svelte`: 中央の「空状態」アイコンのフォーカス定義を共通変数を使用するようにリファクタリング。

## 検証
- [x] `pnpm lint` パス
- [x] `pnpm build` パス
- [x] `pnpm test` 全テストパス
- 手動確認：タブ移動およびクリックによるフォーカス時に、意図したグローが表示されることを確認しました。

## 関連Issue
Closes #50