### PR TITLE
fix: アートワークドロップゾーンのオーバーレイパディングを削減

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.18",
+  "version": "0.13.19",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/src/renderer/src/components/Inspector.svelte
+++ b/src/renderer/src/components/Inspector.svelte
@@ -25,20 +25,22 @@
       />
     {/snippet}
 
-    {#if trackStore.selectedTracks.length > 0}
-      <ArtworkSection />
+    <div class="inspector-content">
+      {#if trackStore.selectedTracks.length > 0}
+        <ArtworkSection />
 
-      <div class="field-container">
-        <BasicFields />
-        <NumericFields />
-        <GenreSection />
-        <TechnicalInfo />
-      </div>
-    {:else}
-      <div class="empty-inspector">
-        <p>Select tracks to edit metadata</p>
-      </div>
-    {/if}
+        <div class="field-container">
+          <BasicFields />
+          <NumericFields />
+          <GenreSection />
+          <TechnicalInfo />
+        </div>
+      {:else}
+        <div class="empty-inspector">
+          <p>Select tracks to edit metadata</p>
+        </div>
+      {/if}
+    </div>
   </DropZone>
 </aside>
 
@@ -48,8 +50,15 @@
     background-color: var(--bg-inspector);
     display: flex;
     flex-direction: column;
+    overflow-y: hidden;
+  }
+
+  .inspector-content {
+    display: flex;
+    flex-direction: column;
     padding: 1.5rem;
     overflow-y: auto;
+    height: 100%;
   }
 
   .field-container {


### PR DESCRIPTION
# 概要
インスペクタのアートワークドロップゾーンに関して、コンテナ(`aside.inspector`)にパディングが適用されているためドロップゾーンのオーバーレイが小さく表示されてしまう問題を修正しました。

# 変更内容
- `Inspector.svelte` の `padding: 1.5rem` を `aside.inspector` から内部の `.inspector-content` に移動しました。
- これにより、`DropZone`コンテナが `aside` 全体に広がり、ドロップオーバーレイが適切なサイズ（インスペクタの全領域-12pxマージン）で表示されるようになります。
- マイナーバージョンをパッチで上げました(`v0.13.19`)。

# 確認事項
- [x] ビルド (`pnpm build`) 成功
- [x] Lint (`pnpm lint`) 成功
- [x] テスト・型チェック (`pnpm typecheck`, `pnpm svelte-check`) 成功