### PR TITLE
fix(ci): パッチリリース時に以前のマイナーバージョンのリリースとタグを削除するようにする (#57)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,24 +94,22 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.check-release.outputs.tag }}
         run: |
-          # 1. タグが vX.Y.Z の形式かチェック
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid tag format. Skipping deletion."
+          # 1. 1つ前のリリースを取得 (最新2件の2番目)
+          PREV_TAG=$(gh release list -L 2 --exclude-drafts --exclude-pre-releases --json tagName -q '.[1].tagName // empty' || true)
+
+          if [[ -z "$PREV_TAG" ]]; then
+            echo "No previous release found. Skipping deletion."
             exit 0
           fi
 
-          # 2. X.Y と Z の部分をBashの標準機能で切り出し
-          MINOR_PREFIX="${TAG%.*}"   # 後ろの .Z を切り落とす (例: v0.13)
-          PATCH_VERSION="${TAG##*.}" # 先頭から . までを切り落とす (例: 1)
+          # 2. X.Y の部分を切り出し（.Z を取り除く）
+          CURRENT_MINOR="${TAG%.*}"
+          PREV_MINOR="${PREV_TAG%.*}"
 
-          # 3. Zが0の場合はマイナーリリース扱いとして削除処理をスキップ
-          if [[ "$PATCH_VERSION" == "0" ]]; then
-            echo "Not a patch release (patch is 0). Skipping deletion."
-            exit 0
+          # 3. メジャー・マイナーが同じなら、1つ前のリリースとタグを削除
+          if [[ "$CURRENT_MINOR" == "$PREV_MINOR" ]]; then
+            echo "Previous release $PREV_TAG has the same minor version ($CURRENT_MINOR). Deleting it..."
+            gh release delete "$PREV_TAG" --yes --cleanup-tag || true
+          else
+            echo "Previous release $PREV_TAG is a different minor version ($PREV_MINOR != $CURRENT_MINOR). Skipping deletion."
           fi
-
-          OLD_TAGS=$(gh release list --json tagName -q ".[].tagName" | grep "^${MINOR_PREFIX}\." | grep -v "^${TAG}$" || true)
-          for old_tag in $OLD_TAGS; do
-            echo "Deleting release and tag: $old_tag"
-            gh release delete "$old_tag" --yes --cleanup-tag || true
-          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
           MINOR_PREFIX=$(echo "$TAG" | sed -E 's/^(v[0-9]+\.[0-9]+)\.[0-9]+$/\1/')
 
           if [[ "$MINOR_PREFIX" != "$TAG" ]]; then
-            OLD_TAGS=$(gh release list --exclude-drafts --exclude-pre-releases -L 100 --json tagName -q ".[].tagName" | grep "^${MINOR_PREFIX}\." | grep -v "^${TAG}$" || true)
+            OLD_TAGS=$(gh release list --json tagName -q ".[].tagName" | grep "^${MINOR_PREFIX}\." | grep -v "^${TAG}$" || true)
             for old_tag in $OLD_TAGS; do
               echo "Deleting release and tag: $old_tag"
               gh release delete "$old_tag" --yes --cleanup-tag || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,10 +96,13 @@ jobs:
         run: |
           MINOR_PREFIX=$(echo "$TAG" | sed -E 's/^(v[0-9]+\.[0-9]+)\.[0-9]+$/\1/')
 
-          if [[ "$MINOR_PREFIX" != "$TAG" ]]; then
-            OLD_TAGS=$(gh release list --json tagName -q ".[].tagName" | grep "^${MINOR_PREFIX}\." | grep -v "^${TAG}$" || true)
-            for old_tag in $OLD_TAGS; do
-              echo "Deleting release and tag: $old_tag"
-              gh release delete "$old_tag" --yes --cleanup-tag || true
-            done
+          if [[ "$MINOR_PREFIX" == "$TAG" ]]; then
+            echo "Not a patch release. Skipping deletion."
+            exit 0
           fi
+
+          OLD_TAGS=$(gh release list --json tagName -q ".[].tagName" | grep "^${MINOR_PREFIX}\." | grep -v "^${TAG}$" || true)
+          for old_tag in $OLD_TAGS; do
+            echo "Deleting release and tag: $old_tag"
+            gh release delete "$old_tag" --yes --cleanup-tag || true
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.check-release.outputs.tag }}
         run: |
-          MINOR_PREFIX=$(echo "$TAG" | sed -E 's/^(v[0-9]+\.[0-9]+)\.[0-9]+$/\1/')
+          # 1. タグが vX.Y.Z の形式かチェック
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid tag format. Skipping deletion."
+            exit 0
+          fi
 
-          if [[ "$MINOR_PREFIX" == "$TAG" ]]; then
-            echo "Not a patch release. Skipping deletion."
+          # 2. X.Y と Z の部分をBashの標準機能で切り出し
+          MINOR_PREFIX="${TAG%.*}"   # 後ろの .Z を切り落とす (例: v0.13)
+          PATCH_VERSION="${TAG##*.}" # 先頭から . までを切り落とす (例: 1)
+
+          # 3. Zが0の場合はマイナーリリース扱いとして削除処理をスキップ
+          if [[ "$PATCH_VERSION" == "0" ]]; then
+            echo "Not a patch release (patch is 0). Skipping deletion."
             exit 0
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
           TAG: ${{ needs.check-release.outputs.tag }}
         run: |
           # 1. 1つ前のリリースを取得 (最新2件の2番目)
-          PREV_TAG=$(gh release list -L 2 --exclude-drafts --exclude-pre-releases --json tagName -q '.[1].tagName // empty' || true)
+          PREV_TAG=$(gh release list -L 2 --json tagName -q '.[1].tagName // empty' || true)
 
           if [[ -z "$PREV_TAG" ]]; then
             echo "No previous release found. Skipping deletion."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,27 +89,23 @@ jobs:
             dist/*.zip \
             dist/latest-mac.yml
 
-      - name: 旧バージョンのリリースとタグの削除
+      - name: 旧バージョンの判定
+        id: check_old_release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.check-release.outputs.tag }}
         run: |
-          # 1. 1つ前のリリースを取得 (最新2件の2番目)
           PREV_TAG=$(gh release list -L 2 --json tagName -q '.[1].tagName // empty' || true)
 
-          if [[ -z "$PREV_TAG" ]]; then
-            echo "No previous release found. Skipping deletion."
-            exit 0
-          fi
-
-          # 2. X.Y の部分を切り出し（.Z を取り除く）
-          CURRENT_MINOR="${TAG%.*}"
-          PREV_MINOR="${PREV_TAG%.*}"
-
-          # 3. メジャー・マイナーが同じなら、1つ前のリリースとタグを削除
-          if [[ "$CURRENT_MINOR" == "$PREV_MINOR" ]]; then
-            echo "Previous release $PREV_TAG has the same minor version ($CURRENT_MINOR). Deleting it..."
-            gh release delete "$PREV_TAG" --yes --cleanup-tag || true
+          if [[ -n "$PREV_TAG" ]] && [[ "${TAG%.*}" == "${PREV_TAG%.*}" ]]; then
+            echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
+            echo "should_delete=true" >> $GITHUB_OUTPUT
           else
-            echo "Previous release $PREV_TAG is a different minor version ($PREV_MINOR != $CURRENT_MINOR). Skipping deletion."
+            echo "should_delete=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: 旧バージョンのリリースとタグの削除
+        if: steps.check_old_release.outputs.should_delete == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release delete "${{ steps.check_old_release.outputs.prev_tag }}" --yes --cleanup-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,3 +88,18 @@ jobs:
             dist/*.dmg \
             dist/*.zip \
             dist/latest-mac.yml
+
+      - name: 旧バージョンのリリースとタグの削除
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.check-release.outputs.tag }}
+        run: |
+          MINOR_PREFIX=$(echo "$TAG" | sed -E 's/^(v[0-9]+\.[0-9]+)\.[0-9]+$/\1/')
+
+          if [[ "$MINOR_PREFIX" != "$TAG" ]]; then
+            OLD_TAGS=$(gh release list --exclude-drafts --exclude-pre-releases -L 100 --json tagName -q ".[].tagName" | grep "^${MINOR_PREFIX}\." | grep -v "^${TAG}$" || true)
+            for old_tag in $OLD_TAGS; do
+              echo "Deleting release and tag: $old_tag"
+              gh release delete "$old_tag" --yes --cleanup-tag || true
+            done
+          fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.18",
+  "version": "0.13.19",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/src/renderer/src/components/Inspector.svelte
+++ b/src/renderer/src/components/Inspector.svelte
@@ -25,20 +25,22 @@
       />
     {/snippet}
 
-    {#if trackStore.selectedTracks.length > 0}
-      <ArtworkSection />
+    <div class="inspector-content">
+      {#if trackStore.selectedTracks.length > 0}
+        <ArtworkSection />
 
-      <div class="field-container">
-        <BasicFields />
-        <NumericFields />
-        <GenreSection />
-        <TechnicalInfo />
-      </div>
-    {:else}
-      <div class="empty-inspector">
-        <p>Select tracks to edit metadata</p>
-      </div>
-    {/if}
+        <div class="field-container">
+          <BasicFields />
+          <NumericFields />
+          <GenreSection />
+          <TechnicalInfo />
+        </div>
+      {:else}
+        <div class="empty-inspector">
+          <p>Select tracks to edit metadata</p>
+        </div>
+      {/if}
+    </div>
   </DropZone>
 </aside>
 
@@ -48,8 +50,15 @@
     background-color: var(--bg-inspector);
     display: flex;
     flex-direction: column;
+    overflow-y: hidden;
+  }
+
+  .inspector-content {
+    display: flex;
+    flex-direction: column;
     padding: 1.5rem;
     overflow-y: auto;
+    height: 100%;
   }
 
   .field-container {


### PR DESCRIPTION
This PR resolves #57 by updating the GitHub release workflow.

### 対応内容
- `.github/workflows/release.yml` に新しいステップ「旧バージョンのリリースとタグの削除」を追加しました。
- このステップでは、新しく作成されるリリースのタグ (例: `v0.13.1`) からマイナーバージョンまでのプレフィックス (例: `v0.13`) を抽出し、同一マイナーバージョンの古いリリースとタグを自動的に削除します。
- これにより、パッチバージョン更新のリリース時に以前の同一マイナーバージョンのタグとリリースが削除されるようになります。

### 検証内容
- `pnpm format`, `pnpm lint`, `pnpm build`, `pnpm test` がエラーなくパスすることを確認しました。