### PR TITLE
fix: tabフォーカス時に削除ボタンが表示されない問題を修正 (#61)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/src/renderer/src/components/inspector/MultiValueField.svelte
+++ b/src/renderer/src/components/inspector/MultiValueField.svelte
@@ -162,19 +162,21 @@
     color: var(--accent-primary);
   }
 
-  /* 削除ボタンは行のホバー時のみ表示 */
+  /* 削除ボタンは行のホバー時またはフォーカス時に表示 */
   .remove-button {
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.2s;
   }
 
-  .value-row:hover .remove-button {
+  .value-row:hover .remove-button,
+  .value-row:focus-within .remove-button {
     opacity: 0.8;
     pointer-events: auto;
   }
 
-  .remove-button:hover {
+  .remove-button:hover,
+  .remove-button:focus-visible {
     color: var(--accent-modified);
     opacity: 1 !important;
   }


### PR DESCRIPTION
GitHub Issue #61 の対応です。

### 変更内容
- `MultiValueField.svelte` の削除ボタン（Xボタン）の表示条件を修正しました。
- これまではホバー時のみ表示されていましたが、Tabキーによるフォーカス時（`:focus-within`）にも表示されるようにしました。
- 削除ボタン自体にフォーカスが当たった際（`:focus-visible`）は、ホバー時と同様にアクセントカラーで強調表示されるようにしました。

### 確認事項
- [x] `pnpm run lint` がパスすることを確認
- [x] `pnpm run test` がパスすることを確認

Closes #61