### PR TITLE
feat: ブラウザ標準の confirm ダイアログをカスタムモーダルに置き換え (#10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.25",
+  "version": "0.13.26",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.24",
+  "version": "0.13.25",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.23",
+  "version": "0.13.24",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",

--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -4,6 +4,7 @@
   import Toolbar from './components/Toolbar.svelte';
   import TrackGrid from './components/TrackGrid.svelte';
   import KeyboardShortcuts from './components/KeyboardShortcuts.svelte';
+  import ConfirmationDialog from './components/ui/ConfirmationDialog.svelte';
 </script>
 
 <KeyboardShortcuts />
@@ -21,6 +22,7 @@
   </section>
 
   <Inspector />
+  <ConfirmationDialog />
 </div>
 
 <style>

--- a/src/renderer/src/components/Toolbar.svelte
+++ b/src/renderer/src/components/Toolbar.svelte
@@ -5,12 +5,16 @@
   import { fileActions } from '@renderer/services/file-actions';
   import { trackStore } from '@renderer/stores/track-store.svelte';
   import { uiState } from '@renderer/stores/ui-state.svelte';
+  import { modalStore } from '@renderer/stores/modal-store.svelte';
 
-  const handleRenameClick = (): void => {
-    const ok = confirm(
-      `Rename ${trackStore.selectedTracks.length} selected files based on metadata?\n` +
-        `Format: {trackNumber} - {title}.flac`
-    );
+  const handleRenameClick = async (): Promise<void> => {
+    const ok = await modalStore.confirm({
+      title: 'Rename Files',
+      message:
+        `Rename ${trackStore.selectedTracks.length} selected files based on metadata?\n` +
+        `Format: {trackNumber} - {title}.flac`,
+      confirmLabel: 'Rename'
+    });
     if (!ok) {
       return;
     }

--- a/src/renderer/src/components/Toolbar.svelte
+++ b/src/renderer/src/components/Toolbar.svelte
@@ -13,7 +13,7 @@
       message:
         `Rename ${trackStore.selectedTracks.length} selected files based on metadata?\n` +
         `Format: {trackNumber} - {title}.flac`,
-      confirmLabel: 'Rename'
+      icon: FilePen
     });
     if (!ok) {
       return;

--- a/src/renderer/src/components/ui/ConfirmationDialog.svelte
+++ b/src/renderer/src/components/ui/ConfirmationDialog.svelte
@@ -1,61 +1,50 @@
 <script lang="ts">
   import { modalStore } from '@renderer/stores/modal-store.svelte';
   import Modal from './Modal.svelte';
-  import { AlertCircle, Info } from '@lucide/svelte';
+  import { Check, X } from '@lucide/svelte';
   import { UI_TOKENS } from '@renderer/constants/design-system';
-
-  // アイコンの選定
-  const iconComponent = $derived.by(() => {
-    switch (modalStore.options.variant) {
-      case 'danger':
-        return AlertCircle;
-      case 'warning':
-        return AlertCircle;
-      default:
-        return Info;
-    }
-  });
-
-  const iconColor = $derived.by(() => {
-    switch (modalStore.options.variant) {
-      case 'danger':
-        return 'var(--accent-error)';
-      case 'warning':
-        return 'var(--accent-warning)';
-      default:
-        return 'var(--accent-primary)';
-    }
-  });
 </script>
 
-<Modal
-  isOpen={modalStore.isOpen}
-  onClose={() => modalStore.handleCancel()}
-  title={modalStore.options.title}
->
-  {#snippet header()}
-    {@const ICON = iconComponent}
-    <div class="header-content">
-      <div class="icon-wrapper" style:color={iconColor}>
-        <ICON size={UI_TOKENS.icons.logoSize} strokeWidth={UI_TOKENS.icons.strokeBold}></ICON>
+{#if modalStore.options}
+  <Modal
+    isOpen={modalStore.isOpen}
+    onClose={() => modalStore.handleCancel()}
+    title={modalStore.options.title}
+  >
+    {#snippet header()}
+      {@const ICON = modalStore.options!.icon}
+      <div class="header-content">
+        <div class="icon-wrapper">
+          <ICON size={UI_TOKENS.icons.logoSize} strokeWidth={UI_TOKENS.icons.strokeBold} />
+        </div>
+        <h2>{modalStore.options!.title}</h2>
       </div>
-      <h2>{modalStore.options.title}</h2>
+    {/snippet}
+
+    <div class="message-container">
+      <p>{modalStore.options!.message}</p>
     </div>
-  {/snippet}
 
-  <div class="message-container">
-    <p>{modalStore.options.message}</p>
-  </div>
-
-  {#snippet footer()}
-    <button class="btn secondary" onclick={() => modalStore.handleCancel()}>
-      {modalStore.options.cancelLabel}
-    </button>
-    <button class="btn {modalStore.options.variant}" onclick={() => modalStore.handleConfirm()}>
-      {modalStore.options.confirmLabel}
-    </button>
-  {/snippet}
-</Modal>
+    {#snippet footer()}
+      <button
+        class="btn cancel"
+        onclick={() => modalStore.handleCancel()}
+        title="Cancel"
+        aria-label="Cancel"
+      >
+        <X size={UI_TOKENS.icons.size} />
+      </button>
+      <button
+        class="btn confirm"
+        onclick={() => modalStore.handleConfirm()}
+        title="Confirm"
+        aria-label="Confirm"
+      >
+        <Check size={UI_TOKENS.icons.size} />
+      </button>
+    {/snippet}
+  </Modal>
+{/if}
 
 <style>
   .header-content {
@@ -68,6 +57,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    color: var(--accent-primary);
   }
 
   .header-content h2 {
@@ -81,54 +71,33 @@
   }
 
   .btn {
-    padding: 0.6rem 1.2rem;
+    padding: 0.4rem;
     border-radius: var(--radius-md);
-    border: none;
-    font-size: 0.9rem;
-    font-weight: 500;
+    border: 1px solid var(--border-primary);
+    background: transparent;
+    color: var(--text-secondary);
     cursor: pointer;
     transition: all 0.2s ease;
-    min-width: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 32px;
+    height: 32px;
   }
 
-  .secondary {
-    background-color: var(--bg-secondary);
-    color: var(--text-primary);
-    border: 1px solid var(--border-primary);
-  }
-
-  .secondary:hover {
+  .btn:hover {
     background-color: var(--bg-hover);
     border-color: var(--border-secondary);
+    color: var(--text-primary);
   }
 
-  .primary {
-    background-color: var(--accent-primary);
-    color: var(--bg-body);
+  .btn.confirm {
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
   }
 
-  .primary:hover {
-    filter: brightness(1.1);
-    box-shadow: 0 0 12px var(--accent-primary-dim);
-  }
-
-  .danger {
-    background-color: var(--accent-error);
-    color: white;
-  }
-
-  .danger:hover {
-    filter: brightness(1.1);
-    box-shadow: 0 0 12px rgba(255, 59, 48, 0.3);
-  }
-
-  .warning {
-    background-color: var(--accent-warning);
-    color: var(--bg-body);
-  }
-
-  .warning:hover {
-    filter: brightness(1.1);
-    box-shadow: 0 0 12px rgba(255, 159, 10, 0.3);
+  .btn.confirm:hover {
+    background-color: var(--accent-primary-dim);
+    box-shadow: 0 0 8px var(--accent-primary-dim);
   }
 </style>

--- a/src/renderer/src/components/ui/ConfirmationDialog.svelte
+++ b/src/renderer/src/components/ui/ConfirmationDialog.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+  import { modalStore } from '@renderer/stores/modal-store.svelte';
+  import Modal from './Modal.svelte';
+  import { AlertCircle, Info } from '@lucide/svelte';
+  import { UI_TOKENS } from '@renderer/constants/design-system';
+
+  // アイコンの選定
+  const iconComponent = $derived.by(() => {
+    switch (modalStore.options.variant) {
+      case 'danger':
+        return AlertCircle;
+      case 'warning':
+        return AlertCircle;
+      default:
+        return Info;
+    }
+  });
+
+  const iconColor = $derived.by(() => {
+    switch (modalStore.options.variant) {
+      case 'danger':
+        return 'var(--accent-error)';
+      case 'warning':
+        return 'var(--accent-warning)';
+      default:
+        return 'var(--accent-primary)';
+    }
+  });
+</script>
+
+<Modal
+  isOpen={modalStore.isOpen}
+  onClose={() => modalStore.handleCancel()}
+  title={modalStore.options.title}
+>
+  {#snippet header()}
+    {@const ICON = iconComponent}
+    <div class="header-content">
+      <div class="icon-wrapper" style:color={iconColor}>
+        <ICON size={UI_TOKENS.icons.logoSize} strokeWidth={UI_TOKENS.icons.strokeBold}></ICON>
+      </div>
+      <h2>{modalStore.options.title}</h2>
+    </div>
+  {/snippet}
+
+  <div class="message-container">
+    <p>{modalStore.options.message}</p>
+  </div>
+
+  {#snippet footer()}
+    <button class="btn secondary" onclick={() => modalStore.handleCancel()}>
+      {modalStore.options.cancelLabel}
+    </button>
+    <button class="btn {modalStore.options.variant}" onclick={() => modalStore.handleConfirm()}>
+      {modalStore.options.confirmLabel}
+    </button>
+  {/snippet}
+</Modal>
+
+<style>
+  .header-content {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .icon-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .header-content h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+  }
+
+  .message-container {
+    color: var(--text-secondary);
+  }
+
+  .btn {
+    padding: 0.6rem 1.2rem;
+    border-radius: var(--radius-md);
+    border: none;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    min-width: 80px;
+  }
+
+  .secondary {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-primary);
+  }
+
+  .secondary:hover {
+    background-color: var(--bg-hover);
+    border-color: var(--border-secondary);
+  }
+
+  .primary {
+    background-color: var(--accent-primary);
+    color: var(--bg-body);
+  }
+
+  .primary:hover {
+    filter: brightness(1.1);
+    box-shadow: 0 0 12px var(--accent-primary-dim);
+  }
+
+  .danger {
+    background-color: var(--accent-error);
+    color: white;
+  }
+
+  .danger:hover {
+    filter: brightness(1.1);
+    box-shadow: 0 0 12px rgba(255, 59, 48, 0.3);
+  }
+
+  .warning {
+    background-color: var(--accent-warning);
+    color: var(--bg-body);
+  }
+
+  .warning:hover {
+    filter: brightness(1.1);
+    box-shadow: 0 0 12px rgba(255, 159, 10, 0.3);
+  }
+</style>

--- a/src/renderer/src/components/ui/ConfirmationDialog.svelte
+++ b/src/renderer/src/components/ui/ConfirmationDialog.svelte
@@ -1,27 +1,24 @@
 <script lang="ts">
-  import { modalStore } from '@renderer/stores/modal-store.svelte';
-  import Modal from './Modal.svelte';
   import { Check, X } from '@lucide/svelte';
   import { UI_TOKENS } from '@renderer/constants/design-system';
-
-  // 非nullアサーションを避けるため、optionsをローカル変数に抽出
-  const options = $derived(modalStore.options);
+  import { modalStore } from '@renderer/stores/modal-store.svelte';
+  import Modal from './Modal.svelte';
 </script>
 
-{#if options}
-  <Modal isOpen={modalStore.isOpen} onClose={() => modalStore.handleCancel()} title={options.title}>
+{#if modalStore.options}
+  {@const { title, message, icon: ICON } = modalStore.options}
+  <Modal isOpen={modalStore.isOpen} onClose={() => modalStore.handleCancel()} {title}>
     {#snippet header()}
-      {@const ICON = options.icon}
       <div class="header-content">
         <div class="icon-wrapper">
           <ICON size={UI_TOKENS.icons.logoSize} strokeWidth={UI_TOKENS.icons.strokeBold} />
         </div>
-        <h2>{options.title}</h2>
+        <h2>{title}</h2>
       </div>
     {/snippet}
 
     <div class="message-container">
-      <p>{options.message}</p>
+      <p>{message}</p>
     </div>
 
     {#snippet footer()}

--- a/src/renderer/src/components/ui/ConfirmationDialog.svelte
+++ b/src/renderer/src/components/ui/ConfirmationDialog.svelte
@@ -3,26 +3,25 @@
   import Modal from './Modal.svelte';
   import { Check, X } from '@lucide/svelte';
   import { UI_TOKENS } from '@renderer/constants/design-system';
+
+  // 非nullアサーションを避けるため、optionsをローカル変数に抽出
+  const options = $derived(modalStore.options);
 </script>
 
-{#if modalStore.options}
-  <Modal
-    isOpen={modalStore.isOpen}
-    onClose={() => modalStore.handleCancel()}
-    title={modalStore.options.title}
-  >
+{#if options}
+  <Modal isOpen={modalStore.isOpen} onClose={() => modalStore.handleCancel()} title={options.title}>
     {#snippet header()}
-      {@const ICON = modalStore.options!.icon}
+      {@const ICON = options.icon}
       <div class="header-content">
         <div class="icon-wrapper">
           <ICON size={UI_TOKENS.icons.logoSize} strokeWidth={UI_TOKENS.icons.strokeBold} />
         </div>
-        <h2>{modalStore.options!.title}</h2>
+        <h2>{options.title}</h2>
       </div>
     {/snippet}
 
     <div class="message-container">
-      <p>{modalStore.options!.message}</p>
+      <p>{options.message}</p>
     </div>
 
     {#snippet footer()}

--- a/src/renderer/src/components/ui/Modal.svelte
+++ b/src/renderer/src/components/ui/Modal.svelte
@@ -22,14 +22,14 @@
 
   // isOpen の変更を監視して showModal / close を制御
   $effect(() => {
+    if (isOpen === dialog.open) {
+      return;
+    }
+
     if (isOpen) {
-      if (!dialog.open) {
-        dialog.showModal();
-      }
+      dialog.showModal();
     } else {
-      if (dialog.open) {
-        dialog.close();
-      }
+      dialog.close();
     }
   });
 

--- a/src/renderer/src/components/ui/Modal.svelte
+++ b/src/renderer/src/components/ui/Modal.svelte
@@ -34,6 +34,7 @@
   });
 
   const handleCancel = (e: Event): void => {
+    // Escキー押下時など、ブラウザ標準のキャンセル動作をハンドル
     e.preventDefault();
     onClose();
   };
@@ -49,29 +50,9 @@
     }
     onClose();
   };
-
-  /**
-   * a11y のためのキーダウンハンドラ。
-   */
-  const handleKeyDown = (e: KeyboardEvent): void => {
-    // ネイティブの dialog は Escape で自動的に閉じられるが、
-    // クリックイベントと対になる操作として Enter/Space を定義。
-    if (e.key === 'Enter' || e.key === ' ') {
-      const target = e.target as HTMLElement;
-      if (target.tagName === 'DIALOG') {
-        onClose();
-      }
-    }
-  };
 </script>
 
-<dialog
-  bind:this={dialog}
-  oncancel={handleCancel}
-  onclick={handleBackdropClick}
-  onkeydown={handleKeyDown}
-  class="custom-modal"
->
+<dialog bind:this={dialog} oncancel={handleCancel} onclick={handleBackdropClick} class="custom-modal">
   <div class="modal-container" role="document">
     <header class="modal-header">
       {#if header}

--- a/src/renderer/src/components/ui/Modal.svelte
+++ b/src/renderer/src/components/ui/Modal.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+  import { type Snippet } from 'svelte';
+
+  interface Props {
+    /** モーダルの開閉状態 */
+    isOpen: boolean;
+    /** モーダルを閉じる際のコールバック */
+    onClose: () => void;
+    /** タイトル (header スニペットが未指定の場合に使用) */
+    title?: string;
+    /** ヘッダー部分のカスタムスニペット */
+    header?: Snippet;
+    /** 本文部分のスニペット */
+    children?: Snippet;
+    /** フッター部分のスニペット */
+    footer?: Snippet;
+  }
+
+  let { isOpen, onClose, title, header, children, footer }: Props = $props();
+
+  let dialog: HTMLDialogElement;
+
+  // isOpen の変更を監視して showModal / close を制御
+  $effect(() => {
+    if (isOpen) {
+      if (!dialog.open) {
+        dialog.showModal();
+      }
+    } else {
+      if (dialog.open) {
+        dialog.close();
+      }
+    }
+  });
+
+  const handleCancel = (e: Event): void => {
+    e.preventDefault();
+    onClose();
+  };
+
+  /**
+   * 背景クリックで閉じる処理。
+   * dialog 要素自体のクリックを検知し、content 外であれば閉じる。
+   */
+  const handleBackdropClick = (e: MouseEvent): void => {
+    const target = e.target as HTMLElement;
+    if (target.tagName === 'DIALOG') {
+      onClose();
+    }
+  };
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<dialog
+  bind:this={dialog}
+  oncancel={handleCancel}
+  onclick={handleBackdropClick}
+  class="custom-modal"
+>
+  <div class="modal-container">
+    <header class="modal-header">
+      {#if header}
+        {@render header()}
+      {:else}
+        <h2>{title}</h2>
+      {/if}
+    </header>
+
+    <main class="modal-body">
+      {#if children}
+        {@render children()}
+      {/if}
+    </main>
+
+    {#if footer}
+      <footer class="modal-footer">
+        {@render footer()}
+      </footer>
+    {/if}
+  </div>
+</dialog>
+
+<style>
+  .custom-modal {
+    padding: 0;
+    border: none;
+    border-radius: var(--radius-xl);
+    background-color: var(--bg-main);
+    box-shadow:
+      0 20px 25px -5px rgba(0, 0, 0, 0.4),
+      0 10px 10px -5px rgba(0, 0, 0, 0.2);
+    color: var(--text-primary);
+    max-width: 480px;
+    width: 90%;
+    border: 1px solid var(--border-primary);
+    overflow: hidden;
+  }
+
+  /* 背景のオーバーレイ */
+  .custom-modal::backdrop {
+    background-color: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+    animation: fade-in 0.2s ease-out;
+  }
+
+  /* モーダル本体のアニメーション */
+  .custom-modal[open] {
+    animation: scale-up 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes scale-up {
+    from {
+      transform: scale(0.95);
+      opacity: 0;
+    }
+    to {
+      transform: scale(1);
+      opacity: 1;
+    }
+  }
+
+  .modal-container {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .modal-header {
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid var(--border-primary);
+    background-color: var(--bg-secondary);
+  }
+
+  .modal-header h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    letter-spacing: -0.01em;
+  }
+
+  .modal-body {
+    padding: 1.5rem;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    white-space: pre-wrap; /* メッセージ内の改行を反映 */
+  }
+
+  .modal-footer {
+    padding: 1rem 1.5rem;
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    background-color: var(--bg-secondary);
+    border-top: 1px solid var(--border-primary);
+  }
+
+  /* モーダルが閉じられる時のアニメーション（将来的な対応用） */
+  /* 現時点では dialog.close() は瞬時に消えるため、CSS のみではアニメーション不可 */
+</style>

--- a/src/renderer/src/components/ui/Modal.svelte
+++ b/src/renderer/src/components/ui/Modal.svelte
@@ -52,7 +52,12 @@
   };
 </script>
 
-<dialog bind:this={dialog} oncancel={handleCancel} onclick={handleBackdropClick} class="custom-modal">
+<dialog
+  bind:this={dialog}
+  oncancel={handleCancel}
+  onclick={handleBackdropClick}
+  class="custom-modal"
+>
   <div class="modal-container" role="document">
     <header class="modal-header">
       {#if header}

--- a/src/renderer/src/components/ui/Modal.svelte
+++ b/src/renderer/src/components/ui/Modal.svelte
@@ -137,7 +137,6 @@
   .modal-header {
     padding: 1.25rem 1.5rem;
     border-bottom: 1px solid var(--border-primary);
-    background-color: var(--bg-secondary);
   }
 
   .modal-header h2 {
@@ -161,7 +160,6 @@
     display: flex;
     justify-content: flex-end;
     gap: 0.75rem;
-    background-color: var(--bg-secondary);
     border-top: 1px solid var(--border-primary);
   }
 

--- a/src/renderer/src/components/ui/Modal.svelte
+++ b/src/renderer/src/components/ui/Modal.svelte
@@ -6,12 +6,12 @@
     isOpen: boolean;
     /** モーダルを閉じる際のコールバック */
     onClose: () => void;
-    /** タイトル (header スニペットが未指定の場合に使用) */
-    title?: string;
+    /** タイトル */
+    title: string;
     /** ヘッダー部分のカスタムスニペット */
     header?: Snippet;
     /** 本文部分のスニペット */
-    children?: Snippet;
+    children: Snippet;
     /** フッター部分のスニペット */
     footer?: Snippet;
   }
@@ -40,25 +40,39 @@
 
   /**
    * 背景クリックで閉じる処理。
-   * dialog 要素自体のクリックを検知し、content 外であれば閉じる。
+   * dialog 要素自体のクリックを検知し、content 外（backdrop）であれば閉じる。
    */
   const handleBackdropClick = (e: MouseEvent): void => {
     const target = e.target as HTMLElement;
-    if (target.tagName === 'DIALOG') {
-      onClose();
+    if (target.tagName !== 'DIALOG') {
+      return;
+    }
+    onClose();
+  };
+
+  /**
+   * a11y のためのキーダウンハンドラ。
+   */
+  const handleKeyDown = (e: KeyboardEvent): void => {
+    // ネイティブの dialog は Escape で自動的に閉じられるが、
+    // クリックイベントと対になる操作として Enter/Space を定義。
+    if (e.key === 'Enter' || e.key === ' ') {
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'DIALOG') {
+        onClose();
+      }
     }
   };
 </script>
 
-<!-- svelte-ignore a11y_click_events_have_key_events -->
-<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <dialog
   bind:this={dialog}
   oncancel={handleCancel}
   onclick={handleBackdropClick}
+  onkeydown={handleKeyDown}
   class="custom-modal"
 >
-  <div class="modal-container">
+  <div class="modal-container" role="document">
     <header class="modal-header">
       {#if header}
         {@render header()}
@@ -68,9 +82,7 @@
     </header>
 
     <main class="modal-body">
-      {#if children}
-        {@render children()}
-      {/if}
+      {@render children()}
     </main>
 
     {#if footer}
@@ -132,11 +144,11 @@
   .modal-container {
     display: flex;
     flex-direction: column;
+    outline: none;
   }
 
   .modal-header {
-    padding: 1.25rem 1.5rem;
-    border-bottom: 1px solid var(--border-primary);
+    padding: 1rem 1.5rem;
   }
 
   .modal-header h2 {
@@ -148,7 +160,7 @@
   }
 
   .modal-body {
-    padding: 1.5rem;
+    padding: 0.75rem 1.5rem;
     font-size: 0.95rem;
     line-height: 1.6;
     color: var(--text-secondary);
@@ -156,13 +168,9 @@
   }
 
   .modal-footer {
-    padding: 1rem 1.5rem;
+    padding: 0.75rem 1.5rem 1rem;
     display: flex;
     justify-content: flex-end;
     gap: 0.75rem;
-    border-top: 1px solid var(--border-primary);
   }
-
-  /* モーダルが閉じられる時のアニメーション（将来的な対応用） */
-  /* 現時点では dialog.close() は瞬時に消えるため、CSS のみではアニメーション不可 */
 </style>

--- a/src/renderer/src/stores/modal-store.svelte.ts
+++ b/src/renderer/src/stores/modal-store.svelte.ts
@@ -1,0 +1,79 @@
+/**
+ * モーダルの設定オプション。
+ */
+export type ModalOptions = {
+  /** モーダルのタイトル */
+  title: string;
+  /** モーダルの本文メッセージ */
+  message: string;
+  /** 確認ボタンのラベル (デフォルト: "OK") */
+  confirmLabel?: string;
+  /** キャンセルボタンのラベル (デフォルト: "Cancel") */
+  cancelLabel?: string;
+  /** ボタンの視覚的バリエーション */
+  variant?: 'primary' | 'danger' | 'warning';
+};
+
+/**
+ * カスタムダイアログの状態と動作を管理するストア。
+ * ブラウザ標準の confirm() と同様の Promise ベースのインターフェースを提供します。
+ */
+class ModalStore {
+  /** モーダルが開いているかどうか */
+  isOpen = $state(false);
+
+  /** 現在のモーダル設定 */
+  options = $state<Required<ModalOptions>>({
+    title: '',
+    message: '',
+    confirmLabel: 'OK',
+    cancelLabel: 'Cancel',
+    variant: 'primary'
+  });
+
+  private resolve: ((value: boolean) => void) | null = null;
+
+  /**
+   * 確認ダイアログを表示し、ユーザーの入力を Promise で返します。
+   * @param options モーダルの設定
+   * @returns ユーザーが確認した場合は true、キャンセルした場合は false
+   */
+  confirm(options: ModalOptions): Promise<boolean> {
+    // 既存の Promise がある場合は、以前の呼び出しをキャンセル（false を返す）
+    if (this.resolve) {
+      this.resolve(false);
+    }
+
+    this.options = {
+      confirmLabel: 'OK',
+      cancelLabel: 'Cancel',
+      variant: 'primary',
+      ...options
+    };
+    this.isOpen = true;
+
+    return new Promise((resolve) => {
+      this.resolve = resolve;
+    });
+  }
+
+  /**
+   * 確認ボタンが押された時のハンドラ。
+   */
+  handleConfirm(): void {
+    this.isOpen = false;
+    this.resolve?.(true);
+    this.resolve = null;
+  }
+
+  /**
+   * キャンセルボタンが押された時、またはダイアログが閉じられた時のハンドラ。
+   */
+  handleCancel(): void {
+    this.isOpen = false;
+    this.resolve?.(false);
+    this.resolve = null;
+  }
+}
+
+export const modalStore = new ModalStore();

--- a/src/renderer/src/stores/modal-store.svelte.ts
+++ b/src/renderer/src/stores/modal-store.svelte.ts
@@ -18,12 +18,26 @@ export type ModalOptions = {
  */
 class ModalStore {
   /** モーダルが開いているかどうか */
-  isOpen = $state(false);
+  #isOpen = $state(false);
 
   /** 現在のモーダル設定 */
-  options = $state<ModalOptions | null>(null);
+  #options = $state<ModalOptions | null>(null);
 
   #resolve: ((value: boolean) => void) | null = null;
+
+  /**
+   * モーダルが開いているかどうかを返します。
+   */
+  get isOpen(): boolean {
+    return this.#isOpen;
+  }
+
+  /**
+   * 現在のモーダル設定を返します。
+   */
+  get options(): ModalOptions | null {
+    return this.#options;
+  }
 
   /**
    * 確認ダイアログを表示し、ユーザーの入力を Promise で返します。
@@ -36,8 +50,8 @@ class ModalStore {
       this.#resolve(false);
     }
 
-    this.options = options;
-    this.isOpen = true;
+    this.#options = options;
+    this.#isOpen = true;
 
     return new Promise((resolve) => {
       this.#resolve = resolve;
@@ -48,7 +62,7 @@ class ModalStore {
    * 確認ボタンが押された時のハンドラ。
    */
   handleConfirm(): void {
-    this.isOpen = false;
+    this.#isOpen = false;
     this.#resolve?.(true);
     this.#resolve = null;
   }
@@ -57,7 +71,7 @@ class ModalStore {
    * キャンセルボタンが押された時、またはダイアログが閉じられた時のハンドラ。
    */
   handleCancel(): void {
-    this.isOpen = false;
+    this.#isOpen = false;
     this.#resolve?.(false);
     this.#resolve = null;
   }

--- a/src/renderer/src/stores/modal-store.svelte.ts
+++ b/src/renderer/src/stores/modal-store.svelte.ts
@@ -1,3 +1,5 @@
+import type { Component } from 'svelte';
+
 /**
  * モーダルの設定オプション。
  */
@@ -6,12 +8,8 @@ export type ModalOptions = {
   title: string;
   /** モーダルの本文メッセージ */
   message: string;
-  /** 確認ボタンのラベル (デフォルト: "OK") */
-  confirmLabel?: string;
-  /** キャンセルボタンのラベル (デフォルト: "Cancel") */
-  cancelLabel?: string;
-  /** ボタンの視覚的バリエーション */
-  variant?: 'primary' | 'danger' | 'warning';
+  /** 表示するアイコン */
+  icon: Component;
 };
 
 /**
@@ -23,15 +21,9 @@ class ModalStore {
   isOpen = $state(false);
 
   /** 現在のモーダル設定 */
-  options = $state<Required<ModalOptions>>({
-    title: '',
-    message: '',
-    confirmLabel: 'OK',
-    cancelLabel: 'Cancel',
-    variant: 'primary'
-  });
+  options = $state<ModalOptions | null>(null);
 
-  private resolve: ((value: boolean) => void) | null = null;
+  #resolve: ((value: boolean) => void) | null = null;
 
   /**
    * 確認ダイアログを表示し、ユーザーの入力を Promise で返します。
@@ -40,20 +32,15 @@ class ModalStore {
    */
   confirm(options: ModalOptions): Promise<boolean> {
     // 既存の Promise がある場合は、以前の呼び出しをキャンセル（false を返す）
-    if (this.resolve) {
-      this.resolve(false);
+    if (this.#resolve) {
+      this.#resolve(false);
     }
 
-    this.options = {
-      confirmLabel: 'OK',
-      cancelLabel: 'Cancel',
-      variant: 'primary',
-      ...options
-    };
+    this.options = options;
     this.isOpen = true;
 
     return new Promise((resolve) => {
-      this.resolve = resolve;
+      this.#resolve = resolve;
     });
   }
 
@@ -62,8 +49,8 @@ class ModalStore {
    */
   handleConfirm(): void {
     this.isOpen = false;
-    this.resolve?.(true);
-    this.resolve = null;
+    this.#resolve?.(true);
+    this.#resolve = null;
   }
 
   /**
@@ -71,8 +58,8 @@ class ModalStore {
    */
   handleCancel(): void {
     this.isOpen = false;
-    this.resolve?.(false);
-    this.resolve = null;
+    this.#resolve?.(false);
+    this.#resolve = null;
   }
 }
 

--- a/src/renderer/src/stores/modal-store.test.ts
+++ b/src/renderer/src/stores/modal-store.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { modalStore } from './modal-store.svelte';
+
+describe('ModalStore', () => {
+  beforeEach(() => {
+    // 状態をリセットするためにキャンセルを呼ぶ
+    modalStore.handleCancel();
+  });
+
+  it('初期状態では閉じていること', () => {
+    expect(modalStore.isOpen).toBe(false);
+  });
+
+  it('confirm を呼ぶと isOpen が true になり、オプションが正しく設定されること', () => {
+    modalStore.confirm({
+      title: 'テストタイトル',
+      message: 'テストメッセージ',
+      confirmLabel: '実行',
+      variant: 'danger'
+    });
+
+    expect(modalStore.isOpen).toBe(true);
+    expect(modalStore.options.title).toBe('テストタイトル');
+    expect(modalStore.options.message).toBe('テストメッセージ');
+    expect(modalStore.options.confirmLabel).toBe('実行');
+    expect(modalStore.options.variant).toBe('danger');
+  });
+
+  it('handleConfirm を呼ぶと Promise が true で解決され、閉じられること', async () => {
+    const confirmPromise = modalStore.confirm({
+      title: 'タイトル',
+      message: 'メッセージ'
+    });
+
+    modalStore.handleConfirm();
+    const result = await confirmPromise;
+
+    expect(result).toBe(true);
+    expect(modalStore.isOpen).toBe(false);
+  });
+
+  it('handleCancel を呼ぶと Promise が false で解決され、閉じられること', async () => {
+    const confirmPromise = modalStore.confirm({
+      title: 'タイトル',
+      message: 'メッセージ'
+    });
+
+    modalStore.handleCancel();
+    const result = await confirmPromise;
+
+    expect(result).toBe(false);
+    expect(modalStore.isOpen).toBe(false);
+  });
+
+  it('新しい confirm を呼ぶと、以前の Promise は false で解決されること', async () => {
+    const firstPromise = modalStore.confirm({ title: '1', message: '1' });
+    const secondPromise = modalStore.confirm({ title: '2', message: '2' });
+
+    const firstResult = await firstPromise;
+    expect(firstResult).toBe(false);
+    expect(modalStore.isOpen).toBe(true);
+    expect(modalStore.options.title).toBe('2');
+
+    modalStore.handleConfirm();
+    const secondResult = await secondPromise;
+    expect(secondResult).toBe(true);
+  });
+});

--- a/src/renderer/src/stores/modal-store.test.ts
+++ b/src/renderer/src/stores/modal-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { modalStore } from './modal-store.svelte';
+import { Info } from '@lucide/svelte';
 
 describe('ModalStore', () => {
   beforeEach(() => {
@@ -15,21 +16,20 @@ describe('ModalStore', () => {
     modalStore.confirm({
       title: 'テストタイトル',
       message: 'テストメッセージ',
-      confirmLabel: '実行',
-      variant: 'danger'
+      icon: Info
     });
 
     expect(modalStore.isOpen).toBe(true);
-    expect(modalStore.options.title).toBe('テストタイトル');
-    expect(modalStore.options.message).toBe('テストメッセージ');
-    expect(modalStore.options.confirmLabel).toBe('実行');
-    expect(modalStore.options.variant).toBe('danger');
+    expect(modalStore.options?.title).toBe('テストタイトル');
+    expect(modalStore.options?.message).toBe('テストメッセージ');
+    expect(modalStore.options?.icon).toBe(Info);
   });
 
   it('handleConfirm を呼ぶと Promise が true で解決され、閉じられること', async () => {
     const confirmPromise = modalStore.confirm({
       title: 'タイトル',
-      message: 'メッセージ'
+      message: 'メッセージ',
+      icon: Info
     });
 
     modalStore.handleConfirm();
@@ -42,7 +42,8 @@ describe('ModalStore', () => {
   it('handleCancel を呼ぶと Promise が false で解決され、閉じられること', async () => {
     const confirmPromise = modalStore.confirm({
       title: 'タイトル',
-      message: 'メッセージ'
+      message: 'メッセージ',
+      icon: Info
     });
 
     modalStore.handleCancel();
@@ -53,13 +54,13 @@ describe('ModalStore', () => {
   });
 
   it('新しい confirm を呼ぶと、以前の Promise は false で解決されること', async () => {
-    const firstPromise = modalStore.confirm({ title: '1', message: '1' });
-    const secondPromise = modalStore.confirm({ title: '2', message: '2' });
+    const firstPromise = modalStore.confirm({ title: '1', message: '1', icon: Info });
+    const secondPromise = modalStore.confirm({ title: '2', message: '2', icon: Info });
 
     const firstResult = await firstPromise;
     expect(firstResult).toBe(false);
     expect(modalStore.isOpen).toBe(true);
-    expect(modalStore.options.title).toBe('2');
+    expect(modalStore.options?.title).toBe('2');
 
     modalStore.handleConfirm();
     const secondResult = await secondPromise;

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -22,6 +22,7 @@
     "strict": true,
     "allowJs": true,
     "checkJs": true,
+    "allowArbitraryExtensions": true,
     "lib": ["ESNext", "DOM", "DOM.Iterable"]
   }
 }


### PR DESCRIPTION
### 概要
ブラウザ標準の `confirm()` ダイアログを、Svelte 5 の Snippet と `<dialog>` 要素を活用したプレミアムなカスタムモーダルに置き換えました。

### 変更点
- **`modalStore` の導入**: Promise ベースで `async/await` による同期的な記述を維持しつつ、モーダルの状態を管理します。
- **汎用 `Modal` コンポーネントの作成**: `<dialog>` 要素を使用し、アクセシビリティとアニメーションを両立したベースコンポーネントを実装しました。
- **`ConfirmationDialog` の実装**: デザインシステムに適合した外観を持つ、確認ダイアログ専用のコンポーネントを実装しました。
- **既存処理の置き換え**: ツールバーのリネーム確認処理を新しいカスタムモーダルに移行しました。

### 検証内容
- [x] `modalStore` のユニットテストがパスすること
- [x] `pnpm build` が正常に完了すること
- [x] `pnpm lint` が正常に完了すること
- [x] ダークモードでのデザインが適切であることを確認

Closes #10