### PR TITLE
fix: Node.js の警告を解消するため type: module を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tag-util",
-  "version": "0.13.27",
+  "version": "0.13.28",
+  "type": "module",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",
   "author": "super-kato",


### PR DESCRIPTION
### 概要
ビルド時（特に `generate-licenses.ts` 実行時）に発生していた Node.js の `MODULE_TYPELESS_PACKAGE_JSON` 警告を解消します。

### 変更内容
- `package.json` に `"type": "module"` を追加
- バージョンを `0.13.28` に更新

これにより、ESM モジュールとして正しく認識されるようになり、ビルド時のパフォーマンス警告が解消されます。

Closes #63
