### PR TITLE
feat: 保存ボタン活性時にglow-pulseアニメーションを適用 #78

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.35",
+  "version": "0.13.36",
   "type": "module",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.36",
+  "version": "0.13.37",
   "type": "module",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/Toolbar.svelte
+++ b/src/renderer/src/components/Toolbar.svelte
@@ -61,6 +61,7 @@
     </button>
     <button
       class="btn primary"
+      class:glow-pulse={!uiState.isLoading && trackStore.tracks.some((t) => t.isModified)}
       onclick={() => tagActions.saveAllModified()}
       disabled={uiState.isLoading || !trackStore.tracks.some((t) => t.isModified)}
       title="Save Changes"

--- a/src/renderer/src/components/Toolbar.svelte
+++ b/src/renderer/src/components/Toolbar.svelte
@@ -21,6 +21,12 @@
 
     fileActions.renameSelectedFiles();
   };
+
+  const canRename = $derived(!uiState.isLoading && trackStore.selectedTracks.length > 0);
+  const canRevert = $derived(
+    !uiState.isLoading && trackStore.selectedTracks.some((t) => t.isModified)
+  );
+  const canSave = $derived(!uiState.isLoading && trackStore.tracks.some((t) => t.isModified));
 </script>
 
 <header class="toolbar">
@@ -46,7 +52,7 @@
     <button
       class="btn secondary"
       onclick={handleRenameClick}
-      disabled={uiState.isLoading || trackStore.selectedTracks.length === 0}
+      disabled={!canRename}
       title="Rename Files from Metadata"
     >
       <FilePen size={UI_TOKENS.icons.size} />
@@ -54,16 +60,16 @@
     <button
       class="btn revert"
       onclick={() => tagActions.revertSelected()}
-      disabled={uiState.isLoading || !trackStore.selectedTracks.some((t) => t.isModified)}
+      disabled={!canRevert}
       title="Revert Changes"
     >
       <RotateCcw size={UI_TOKENS.icons.size} />
     </button>
     <button
       class="btn primary"
-      class:glow-pulse={!uiState.isLoading && trackStore.tracks.some((t) => t.isModified)}
+      class:glow-pulse={canSave}
       onclick={() => tagActions.saveAllModified()}
-      disabled={uiState.isLoading || !trackStore.tracks.some((t) => t.isModified)}
+      disabled={!canSave}
       title="Save Changes"
     >
       {#if uiState.isLoading}

--- a/src/renderer/src/components/TrackGrid.svelte
+++ b/src/renderer/src/components/TrackGrid.svelte
@@ -73,7 +73,7 @@
     {:else}
       <div class="empty-state">
         <button
-          class="empty-icon"
+          class="empty-icon glow-pulse"
           onclick={tagActions.openAndScanDirectory}
           aria-label="Open Directory"
         >
@@ -210,7 +210,6 @@
     border: 1px solid var(--border-primary);
     /* パルスするグロー効果 */
     box-shadow: 0 0 15px var(--selection-glow);
-    animation: glow-pulse 2s infinite ease-in-out;
     cursor: pointer;
     transition: all 0.2s ease;
     padding: 0;

--- a/src/renderer/src/components/ui/ConfirmationDialog.svelte
+++ b/src/renderer/src/components/ui/ConfirmationDialog.svelte
@@ -31,7 +31,7 @@
         <X size={UI_TOKENS.icons.size} />
       </button>
       <button
-        class="btn confirm"
+        class="btn confirm glow-pulse"
         onclick={() => modalStore.handleConfirm()}
         title="Confirm"
         aria-label="Confirm"
@@ -84,6 +84,5 @@
   .btn.confirm {
     border-color: var(--accent-primary);
     color: var(--accent-primary);
-    animation: glow-pulse 2s infinite ease-in-out;
   }
 </style>

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -128,6 +128,10 @@ body {
   }
 }
 
+.glow-pulse {
+  animation: glow-pulse 2s infinite ease-in-out;
+}
+
 /* --- コンポーネント共通のベース UI (Form) --- */
 .field {
   display: flex;


### PR DESCRIPTION
## 概要
GitHub issue #78 に対応しました。
保存ボタンが活性（変更がある状態）の時に、ユーザーの注意を引くための `glow-pulse` アニメーションを適用しました。

## 変更内容
- `src/renderer/src/index.css`: `.glow-pulse` ユーティリティクラスを追加。
- `src/renderer/src/components/Toolbar.svelte`: 保存ボタンに `glow-pulse` クラスを条件付きで適用。
- `src/renderer/src/components/TrackGrid.svelte`: 既存の `glow-pulse` アニメーションをユーティリティクラスに移行。
- `src/renderer/src/components/ui/ConfirmationDialog.svelte`: 既存の `glow-pulse` アニメーションをユーティリティクラスに移行。
- `package.json`: バージョンを `0.13.36` に更新。

## 検証内容
- `pnpm lint`: PASS
- `pnpm test`: PASS
- `pnpm build`: PASS (Typecheck含む)
- 手動確認: 変更がある場合に保存ボタンがパルス状に発光することを確認。