### PR TITLE
fix: 複数選択時（divergent）でもジャンルのフリーテキスト編集を可能にする (#82)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.37",
+  "version": "0.13.38",
   "type": "module",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/inspector/BadgeField.svelte
+++ b/src/renderer/src/components/inspector/BadgeField.svelte
@@ -48,30 +48,27 @@
     onclick={handleClickContainer}
     role="presentation"
   >
-    {#if isUniform}
-      {#each values as val, i (i)}
-        <span class="badge">
-          {val}
-          <button
-            type="button"
-            class="remove-btn no-hover-glow"
-            onclick={() => onRemove(val)}
-            title="Remove"
-          >
-            <X size={UI_TOKENS.icons.sizeSmall} strokeWidth={UI_TOKENS.icons.strokeBold} />
-          </button>
-        </span>
-      {/each}
-      <input
-        id="badge-input-{label}"
-        type="text"
-        bind:value={inputValue}
-        onkeydown={handleKeyDown}
-        autocomplete="off"
-      />
-    {:else}
-      <div class="mixed-placeholder">Mixed Values (Click to unify)</div>
-    {/if}
+    {#each values as val, i (i)}
+      <span class="badge" class:divergent-badge={!isUniform}>
+        {val}
+        <button
+          type="button"
+          class="remove-btn no-hover-glow"
+          onclick={() => onRemove(val)}
+          title={isUniform ? 'Remove' : 'Remove from all tracks'}
+        >
+          <X size={UI_TOKENS.icons.sizeSmall} strokeWidth={UI_TOKENS.icons.strokeBold} />
+        </button>
+      </span>
+    {/each}
+    <input
+      id="badge-input-{label}"
+      type="text"
+      bind:value={inputValue}
+      onkeydown={handleKeyDown}
+      autocomplete="off"
+      placeholder={!isUniform && values.length === 0 ? 'Mixed Values' : ''}
+    />
   </div>
 </div>
 
@@ -96,13 +93,8 @@
   }
 
   .badge-container.divergent {
-    opacity: 0.6;
     background-color: var(--bg-header);
-    cursor: pointer;
-    justify-content: center;
-    align-items: center;
-    font-style: italic;
-    color: var(--text-muted);
+    cursor: text;
   }
 
   .badge {
@@ -116,6 +108,13 @@
     font-size: 0.8rem;
     border: 1px solid var(--border-secondary);
     animation: badge-in 0.2s ease-out;
+  }
+
+  .badge.divergent-badge {
+    opacity: 0.8;
+    border-style: dashed;
+    font-style: italic;
+    color: var(--text-dim);
   }
 
   @keyframes badge-in {

--- a/src/renderer/src/components/inspector/BasicFields.svelte
+++ b/src/renderer/src/components/inspector/BasicFields.svelte
@@ -1,19 +1,13 @@
 <script lang="ts">
   import { trackStore } from '@renderer/stores/track-store.svelte';
   import { tagActions } from '@renderer/services/tag-actions';
-  import type { FieldState } from '@domain/editor/batch-metadata';
-  import MultiValueField from './MultiValueField.svelte';
-  import { getSingleFieldValue, handleSingleInput } from './tag-field-handlers';
 
-  const getMultiFieldValues = (state: FieldState<string[] | undefined>): string[] => {
-    if (state.type === 'uniform') {
-      return state.value ?? [];
-    }
-    if (state.type === 'divergent') {
-      return state.values ?? [];
-    }
-    return [];
-  };
+  import MultiValueField from './MultiValueField.svelte';
+  import {
+    getSingleFieldValue,
+    handleSingleInput,
+    getMultiFieldValues
+  } from './tag-field-handlers';
 </script>
 
 {#if trackStore.commonMetadata}

--- a/src/renderer/src/components/inspector/GenreSection.svelte
+++ b/src/renderer/src/components/inspector/GenreSection.svelte
@@ -21,7 +21,7 @@
   <div class="genre-section">
     <BadgeField
       label="Genre"
-      values={genreState.type === 'uniform' ? (genreState.value ?? []) : []}
+      values={genreState.type === 'uniform' ? (genreState.value ?? []) : (genreState.values ?? [])}
       isUniform={genreState.type === 'uniform'}
       onAdd={(v) => applyGenre(v)}
       onRemove={(v) => tagActions.removeSelectedMultiFieldValue('genre', v)}

--- a/src/renderer/src/components/inspector/GenreSection.svelte
+++ b/src/renderer/src/components/inspector/GenreSection.svelte
@@ -3,6 +3,7 @@
   import { trackStore } from '@renderer/stores/track-store.svelte';
   import { tagActions } from '@renderer/services/tag-actions';
   import BadgeField from './BadgeField.svelte';
+  import { getMultiFieldValues } from './tag-field-handlers';
 
   const MAX_QUICK_GENRES = 4;
   const QUICK_GENRES = DEFAULT_GENRES.slice(0, MAX_QUICK_GENRES);
@@ -21,7 +22,7 @@
   <div class="genre-section">
     <BadgeField
       label="Genre"
-      values={genreState.type === 'uniform' ? (genreState.value ?? []) : (genreState.values ?? [])}
+      values={getMultiFieldValues(genreState)}
       isUniform={genreState.type === 'uniform'}
       onAdd={(v) => applyGenre(v)}
       onRemove={(v) => tagActions.removeSelectedMultiFieldValue('genre', v)}

--- a/src/renderer/src/components/inspector/tag-field-handlers.ts
+++ b/src/renderer/src/components/inspector/tag-field-handlers.ts
@@ -31,5 +31,12 @@ export const getSingleFieldValue = (key: EditableSingleKey): string => {
  * 複数値フィールドの表示用の実効値リストを取得します。
  * Uniform の場合はその値を、Divergent の場合は和（union）を返します。
  */
-export const getMultiFieldValues = (state: FieldState<string[] | undefined>): string[] =>
-  (state.type === 'uniform' ? state.value : state.values) ?? [];
+export const getMultiFieldValues = (state: FieldState<string[] | undefined>): string[] => {
+  if (state.type === 'uniform') {
+    return state.value ?? [];
+  }
+  if (state.type === 'divergent') {
+    return state.values ?? [];
+  }
+  return [];
+};

--- a/src/renderer/src/components/inspector/tag-field-handlers.ts
+++ b/src/renderer/src/components/inspector/tag-field-handlers.ts
@@ -1,4 +1,4 @@
-import type { EditableSingleKey } from '@domain/editor/batch-metadata';
+import type { EditableSingleKey, FieldState } from '@domain/editor/batch-metadata';
 import { trackStore } from '@renderer/stores/track-store.svelte';
 import { tagActions } from '@renderer/services/tag-actions';
 
@@ -25,4 +25,18 @@ export const getSingleFieldValue = (key: EditableSingleKey): string => {
     return '';
   }
   return state.value ?? '';
+};
+
+/**
+ * 複数値フィールドの表示用の実効値リストを取得します。
+ * Uniform の場合はその値を、Divergent の場合は和（union）を返します。
+ */
+export const getMultiFieldValues = (state: FieldState<string[] | undefined>): string[] => {
+  if (state.type === 'uniform') {
+    return state.value ?? [];
+  }
+  if (state.type === 'divergent') {
+    return state.values ?? [];
+  }
+  return [];
 };

--- a/src/renderer/src/components/inspector/tag-field-handlers.ts
+++ b/src/renderer/src/components/inspector/tag-field-handlers.ts
@@ -31,12 +31,5 @@ export const getSingleFieldValue = (key: EditableSingleKey): string => {
  * 複数値フィールドの表示用の実効値リストを取得します。
  * Uniform の場合はその値を、Divergent の場合は和（union）を返します。
  */
-export const getMultiFieldValues = (state: FieldState<string[] | undefined>): string[] => {
-  if (state.type === 'uniform') {
-    return state.value ?? [];
-  }
-  if (state.type === 'divergent') {
-    return state.values ?? [];
-  }
-  return [];
-};
+export const getMultiFieldValues = (state: FieldState<string[] | undefined>): string[] =>
+  (state.type === 'uniform' ? state.value : state.values) ?? [];


### PR DESCRIPTION
GitHub issue #82 に対応しました。

### 変更内容
- **複数選択時のジャンル編集の改善**:
    - `GenreSection` において、選択されたトラック間でジャンルが異なる場合（divergent）でも、それらのジャンルの和（union）を `BadgeField` に渡すように変更しました。
    - `BadgeField` コンポーネントを修正し、`isUniform` の状態に関わらず常に入力欄とバッジを表示するようにしました。これにより、複数選択時でもフリーテキストで新しいジャンルを追加できるようになりました。
- **UI/UX の調整**:
    - `divergent` 状態のバッジは、破線かつ斜体のスタイル（`divergent-badge`）を適用し、すべてのトラックに共通でないことを視覚的に示しました。
    - バッジの削除ボタンのツールチップを、一様な場合は「Remove」、非一様な場合は「Remove from all tracks」と表示されるように改善しました。
- **バージョン更新**:
    - `package.json` のバージョンを `0.13.38` に更新しました。

### 検証内容
- `pnpm format`: パス
- `pnpm lint`: パス
- `pnpm test`: パス（既存のテストスイートが正常に動作することを確認）
- `pnpm build`: パス

Closes #82