### PR TITLE
build: electron-builder.yml の設定見直し (#79)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -4,8 +4,6 @@ publish:
   provider: github
   owner: super-kato
   repo: TagUtil
-directories:
-  buildResources: build
 files:
   - '!**/.vscode/*'
   - '!src/*'
@@ -17,9 +15,9 @@ files:
 asarUnpack:
   - resources/**
 win:
-  executableName: tag-util
+  executableName: TagUtil
 nsis:
-  artifactName: ${name}-${version}-setup.${ext}
+  artifactName: ${productName}-${version}-setup.${ext}
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
@@ -29,19 +27,16 @@ mac:
   gatekeeperAssess: false
   notarize: true
   extendInfo:
-    - NSCameraUsageDescription: Application requests access to the device's camera.
-    - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
 dmg:
-  artifactName: ${name}.${ext}
+  artifactName: ${productName}-${version}.${ext}
 linux:
   target:
     - AppImage
     - snap
     - deb
-  maintainer: electronjs.org
+  maintainer: super-kato
   category: Utility
 appImage:
-  artifactName: ${name}-${version}.${ext}
-npmRebuild: false
+  artifactName: ${productName}-${version}.${ext}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.38",
+  "version": "0.13.39",
   "type": "module",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",


### PR DESCRIPTION
GitHub Issue #79 に対応しました。

`electron-builder.yml` の設定を見直し、不要なプロパティや不適切な設定を修正しました。

### 修正内容
- **不要なプロパティの削除**:
    - デフォルト設定である `directories.buildResources: build` を削除しました。
    - `npmRebuild: false` を削除し、必要に応じて native modules のビルドが行われるようにしました。
- **macOS 設定の修正**:
    - アプリケーションで利用していないカメラ (`NSCameraUsageDescription`) およびマイク (`NSMicrophoneUsageDescription`) の権限要求を削除しました。
- **Linux 設定の修正**:
    - `maintainer` を `electronjs.org` から `super-kato` に更新しました。
- **命名規則の統一**:
    - Windows の `executableName` を `productName` と同じ `TagUtil` に変更しました。
    - 各プラットフォームの `artifactName` を `${productName}-${version}.${ext}` の形式に統一しました。

### 検証内容
- `pnpm format`: PASS
- `pnpm lint`: PASS
- `pnpm test`: PASS
- `pnpm build`: PASS (ビルド後の `out` ディレクトリ生成を確認)

ご確認をお願いします。