### PR TITLE
feat: 複数選択時のAutoボタンで総トラック数も自動入力するように変更 #77

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.39",
+  "version": "0.13.40",
   "type": "module",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",

--- a/src/renderer/src/services/tag-editor.test.ts
+++ b/src/renderer/src/services/tag-editor.test.ts
@@ -74,4 +74,23 @@ describe('tagEditor', () => {
       expect(track.metadata.album).toBe('New Album');
     });
   });
+
+  describe('applyAutoNumbering', () => {
+    it('選択されたトラックに連番と総数を設定すること', () => {
+      const tracks = [
+        createMockTrack('file1.flac'),
+        createMockTrack('file2.flac'),
+        createMockTrack('file3.flac')
+      ];
+
+      tagEditor.applyAutoNumbering(tracks);
+
+      expect(tracks[0].metadata.trackNumber).toBe('1');
+      expect(tracks[0].metadata.trackTotal).toBe('3');
+      expect(tracks[1].metadata.trackNumber).toBe('2');
+      expect(tracks[1].metadata.trackTotal).toBe('3');
+      expect(tracks[2].metadata.trackNumber).toBe('3');
+      expect(tracks[2].metadata.trackTotal).toBe('3');
+    });
+  });
 });

--- a/src/renderer/src/services/tag-editor.ts
+++ b/src/renderer/src/services/tag-editor.ts
@@ -81,11 +81,14 @@ const removePicture = (tracks: TrackRecord[]): void => {
 
 /**
  * トラック番号の自動採番（1, 2, 3...）を適用します。
+ * 同時に総トラック数も選択数に合わせて更新します。
  */
 const applyAutoNumbering = (tracks: TrackRecord[]): void => {
+  const total = tracks.length;
   tracks.forEach((track, index) => {
     const num = index + 1;
     track.metadata.trackNumber = num.toString();
+    track.metadata.trackTotal = total.toString();
   });
 };
 


### PR DESCRIPTION
### 概要
複数選択時のトラック番号「Auto」ボタンをクリックした際、個別のトラック番号（1, 2...）だけでなく、選択されたトラックの総数を `trackTotal` フィールドに自動入力するように変更しました。

### 変更内容
- `src/renderer/src/services/tag-editor.ts`: `applyAutoNumbering` 関数を修正し、`trackTotal` も設定するようにしました。
- `src/renderer/src/services/tag-editor.test.ts`: `applyAutoNumbering` のテストケースを追加し、正常に動作することを確認しました。
- `package.json`: バージョンを `0.13.40` に更新しました。

### 検証内容
- [x] `pnpm test` にて新規追加したテストを含む全てのテストがパスすることを確認
- [x] `pnpm lint` および `pnpm format` でコード品質を確認
- [x] `pnpm build` でビルドが正常に完了することを確認

Closes #77