### PR TITLE
feat: genreのサジェスト機能を実装 (#83)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.41",
+  "version": "0.13.42",
   "type": "module",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.43",
+  "version": "0.13.44",
   "type": "module",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.40",
+  "version": "0.13.41",
   "type": "module",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.42",
+  "version": "0.13.43",
   "type": "module",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/inspector/BadgeField.svelte
+++ b/src/renderer/src/components/inspector/BadgeField.svelte
@@ -16,10 +16,7 @@
   let inputValue = $state('');
   let inputElement: HTMLInputElement | undefined = $state();
 
-  const filteredSuggestions = $derived.by(() => {
-    // 既に追加されている値はサジェストから除外
-    return suggestions.filter((s) => !values.includes(s));
-  });
+  const filteredSuggestions = $derived(suggestions.filter((s) => !values.includes(s)));
 
   const handleKeyDown = (e: KeyboardEvent): void => {
     if (e.key === 'Enter' || e.key === ',') {

--- a/src/renderer/src/components/inspector/BadgeField.svelte
+++ b/src/renderer/src/components/inspector/BadgeField.svelte
@@ -6,35 +6,85 @@
     label: string;
     values: string[];
     isUniform: boolean;
-    placeholder?: string;
+    suggestions?: string[];
     onAdd: (value: string) => void;
     onRemove: (value: string) => void;
   }
 
-  let { label, values, isUniform, onAdd, onRemove }: Props = $props();
+  let { label, values, isUniform, suggestions = [], onAdd, onRemove }: Props = $props();
+
+  const NO_SELECTION = -1;
+  const MAX_SUGGESTIONS = 10;
+  const BLUR_TIMEOUT_MS = 200;
 
   let inputValue = $state('');
+  let selectedIndex = $state(NO_SELECTION);
+  let showSuggestions = $state(false);
+  let inputElement: HTMLInputElement | undefined = $state();
+
+  const filteredSuggestions = $derived.by(() => {
+    const query = inputValue.trim().toLowerCase();
+    if (!query) {
+      return [];
+    }
+    return suggestions
+      .filter((s) => s.toLowerCase().includes(query) && !values.includes(s))
+      .slice(0, MAX_SUGGESTIONS);
+  });
+
+  const selectSuggestion = (suggestion: string): void => {
+    onAdd(suggestion);
+    inputValue = '';
+    showSuggestions = false;
+    selectedIndex = NO_SELECTION;
+    inputElement?.focus();
+  };
 
   const handleKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === 'Enter' || e.key === ',') {
-      e.preventDefault();
-      const val = inputValue.trim();
-      if (val) {
-        onAdd(val);
-        inputValue = '';
+    if (e.key === 'ArrowDown') {
+      if (filteredSuggestions.length > 0) {
+        e.preventDefault();
+        showSuggestions = true;
+        selectedIndex = Math.min(selectedIndex + 1, filteredSuggestions.length - 1);
       }
+    } else if (e.key === 'ArrowUp') {
+      if (showSuggestions && filteredSuggestions.length > 0) {
+        e.preventDefault();
+        selectedIndex = Math.max(selectedIndex - 1, NO_SELECTION);
+      }
+    } else if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      if (selectedIndex >= 0 && filteredSuggestions[selectedIndex]) {
+        selectSuggestion(filteredSuggestions[selectedIndex]);
+      } else {
+        const val = inputValue.trim();
+        if (val) {
+          onAdd(val);
+          inputValue = '';
+          showSuggestions = false;
+          selectedIndex = NO_SELECTION;
+        }
+      }
+    } else if (e.key === 'Escape') {
+      showSuggestions = false;
+      selectedIndex = NO_SELECTION;
     } else if (e.key === 'Backspace' && inputValue === '' && values.length > 0) {
-      // 入力欄が空の状態でバックスペースを押すと最後の項目を削除
       onRemove(values[values.length - 1]);
     }
   };
 
+  const handleBlur = (): void => {
+    // クリックイベントが先に発生するように少し遅らせる
+    setTimeout(() => {
+      showSuggestions = false;
+      selectedIndex = NO_SELECTION;
+    }, BLUR_TIMEOUT_MS);
+  };
+
   const handleClickContainer = (e: MouseEvent): void => {
-    // コンテナクリックで中の入力欄にフォーカスを当てる
     const target = e.target as HTMLElement;
     if (target.classList.contains('badge-container')) {
-      const input = target.querySelector('input');
-      input?.focus();
+      inputElement?.focus();
     }
   };
 </script>
@@ -61,14 +111,38 @@
         </button>
       </span>
     {/each}
-    <input
-      id="badge-input-{label}"
-      type="text"
-      bind:value={inputValue}
-      onkeydown={handleKeyDown}
-      autocomplete="off"
-      placeholder={!isUniform && values.length === 0 ? 'Mixed Values' : ''}
-    />
+    <div class="input-wrapper">
+      <input
+        id="badge-input-{label}"
+        type="text"
+        bind:this={inputElement}
+        bind:value={inputValue}
+        onkeydown={handleKeyDown}
+        onfocus={() => (showSuggestions = true)}
+        onblur={handleBlur}
+        oninput={() => (selectedIndex = NO_SELECTION)}
+        autocomplete="off"
+        placeholder={!isUniform && values.length === 0 ? 'Mixed Values' : ''}
+      />
+
+      {#if showSuggestions && filteredSuggestions.length > 0}
+        <ul class="suggestions-list">
+          {#each filteredSuggestions as suggestion, i (suggestion)}
+            <li class:selected={i === selectedIndex}>
+              <button
+                type="button"
+                onmousedown={(e) => {
+                  e.preventDefault(); // blurを防ぐ
+                  selectSuggestion(suggestion);
+                }}
+              >
+                {suggestion}
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
   </div>
 </div>
 
@@ -155,9 +229,15 @@
     opacity: 1 !important;
   }
 
-  .badge-container input {
+  .input-wrapper {
+    position: relative;
     flex: 1;
-    min-width: 60px;
+    display: flex;
+    min-width: 120px;
+  }
+
+  .badge-container input {
+    width: 100%;
     background: transparent;
     border: none;
     color: var(--text-primary);
@@ -168,5 +248,42 @@
 
   .badge-container input::placeholder {
     color: var(--text-dim);
+  }
+
+  .suggestions-list {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    left: 0;
+    right: 0;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-primary);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    z-index: 100;
+    list-style: none;
+    padding: 0.25rem;
+    margin: 0;
+    min-width: 200px;
+    max-height: 250px;
+    overflow-y: auto;
+  }
+
+  .suggestions-list li button {
+    width: 100%;
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    border: none;
+    background: none;
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  .suggestions-list li.selected button,
+  .suggestions-list li button:hover {
+    background: var(--bg-hover);
+    color: var(--accent-primary);
   }
 </style>

--- a/src/renderer/src/components/inspector/BadgeField.svelte
+++ b/src/renderer/src/components/inspector/BadgeField.svelte
@@ -13,72 +13,25 @@
 
   let { label, values, isUniform, suggestions = [], onAdd, onRemove }: Props = $props();
 
-  const NO_SELECTION = -1;
-  const MAX_SUGGESTIONS = 10;
-  const BLUR_TIMEOUT_MS = 200;
-
   let inputValue = $state('');
-  let selectedIndex = $state(NO_SELECTION);
-  let showSuggestions = $state(false);
   let inputElement: HTMLInputElement | undefined = $state();
 
   const filteredSuggestions = $derived.by(() => {
-    const query = inputValue.trim().toLowerCase();
-    if (!query) {
-      return [];
-    }
-    return suggestions
-      .filter((s) => s.toLowerCase().includes(query) && !values.includes(s))
-      .slice(0, MAX_SUGGESTIONS);
+    // 既に追加されている値はサジェストから除外
+    return suggestions.filter((s) => !values.includes(s));
   });
 
-  const selectSuggestion = (suggestion: string): void => {
-    onAdd(suggestion);
-    inputValue = '';
-    showSuggestions = false;
-    selectedIndex = NO_SELECTION;
-    inputElement?.focus();
-  };
-
   const handleKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === 'ArrowDown') {
-      if (filteredSuggestions.length > 0) {
-        e.preventDefault();
-        showSuggestions = true;
-        selectedIndex = Math.min(selectedIndex + 1, filteredSuggestions.length - 1);
-      }
-    } else if (e.key === 'ArrowUp') {
-      if (showSuggestions && filteredSuggestions.length > 0) {
-        e.preventDefault();
-        selectedIndex = Math.max(selectedIndex - 1, NO_SELECTION);
-      }
-    } else if (e.key === 'Enter' || e.key === ',') {
+    if (e.key === 'Enter' || e.key === ',') {
       e.preventDefault();
-      if (selectedIndex >= 0 && filteredSuggestions[selectedIndex]) {
-        selectSuggestion(filteredSuggestions[selectedIndex]);
-      } else {
-        const val = inputValue.trim();
-        if (val) {
-          onAdd(val);
-          inputValue = '';
-          showSuggestions = false;
-          selectedIndex = NO_SELECTION;
-        }
+      const val = inputValue.trim();
+      if (val) {
+        onAdd(val);
+        inputValue = '';
       }
-    } else if (e.key === 'Escape') {
-      showSuggestions = false;
-      selectedIndex = NO_SELECTION;
     } else if (e.key === 'Backspace' && inputValue === '' && values.length > 0) {
       onRemove(values[values.length - 1]);
     }
-  };
-
-  const handleBlur = (): void => {
-    // クリックイベントが先に発生するように少し遅らせる
-    setTimeout(() => {
-      showSuggestions = false;
-      selectedIndex = NO_SELECTION;
-    }, BLUR_TIMEOUT_MS);
   };
 
   const handleClickContainer = (e: MouseEvent): void => {
@@ -115,33 +68,18 @@
       <input
         id="badge-input-{label}"
         type="text"
+        list="suggestions-{label}"
         bind:this={inputElement}
         bind:value={inputValue}
         onkeydown={handleKeyDown}
-        onfocus={() => (showSuggestions = true)}
-        onblur={handleBlur}
-        oninput={() => (selectedIndex = NO_SELECTION)}
         autocomplete="off"
         placeholder={!isUniform && values.length === 0 ? 'Mixed Values' : ''}
       />
-
-      {#if showSuggestions && filteredSuggestions.length > 0}
-        <ul class="suggestions-list">
-          {#each filteredSuggestions as suggestion, i (suggestion)}
-            <li class:selected={i === selectedIndex}>
-              <button
-                type="button"
-                onmousedown={(e) => {
-                  e.preventDefault(); // blurを防ぐ
-                  selectSuggestion(suggestion);
-                }}
-              >
-                {suggestion}
-              </button>
-            </li>
-          {/each}
-        </ul>
-      {/if}
+      <datalist id="suggestions-{label}">
+        {#each filteredSuggestions as suggestion (suggestion)}
+          <option value={suggestion}></option>
+        {/each}
+      </datalist>
     </div>
   </div>
 </div>
@@ -230,7 +168,6 @@
   }
 
   .input-wrapper {
-    position: relative;
     flex: 1;
     display: flex;
     min-width: 120px;
@@ -248,42 +185,5 @@
 
   .badge-container input::placeholder {
     color: var(--text-dim);
-  }
-
-  .suggestions-list {
-    position: absolute;
-    top: calc(100% + 0.5rem);
-    left: 0;
-    right: 0;
-    background: var(--bg-secondary);
-    border: 1px solid var(--border-primary);
-    border-radius: var(--radius-md);
-    box-shadow: var(--shadow-lg);
-    z-index: 100;
-    list-style: none;
-    padding: 0.25rem;
-    margin: 0;
-    min-width: 200px;
-    max-height: 250px;
-    overflow-y: auto;
-  }
-
-  .suggestions-list li button {
-    width: 100%;
-    text-align: left;
-    padding: 0.5rem 0.75rem;
-    border: none;
-    background: none;
-    color: var(--text-primary);
-    font-size: 0.85rem;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.15s;
-  }
-
-  .suggestions-list li.selected button,
-  .suggestions-list li button:hover {
-    background: var(--bg-hover);
-    color: var(--accent-primary);
   }
 </style>

--- a/src/renderer/src/components/inspector/GenreSection.svelte
+++ b/src/renderer/src/components/inspector/GenreSection.svelte
@@ -24,6 +24,7 @@
       label="Genre"
       values={getMultiFieldValues(genreState)}
       isUniform={genreState.type === 'uniform'}
+      suggestions={trackStore.allGenres}
       onAdd={(v) => applyGenre(v)}
       onRemove={(v) => tagActions.removeSelectedMultiFieldValue('genre', v)}
     />
@@ -33,7 +34,7 @@
         <button class="genre-badge" onclick={() => applyGenre(g)}>
           {g}
         </button>
-      {/each}
+      {#/each}
     </div>
   </div>
 {/if}

--- a/src/renderer/src/components/inspector/GenreSection.svelte
+++ b/src/renderer/src/components/inspector/GenreSection.svelte
@@ -34,7 +34,7 @@
         <button class="genre-badge" onclick={() => applyGenre(g)}>
           {g}
         </button>
-      {#/each}
+      {/each}
     </div>
   </div>
 {/if}


### PR DESCRIPTION
GitHub Issue #83 の対応です。

### 変更内容
- `BadgeField.svelte`: サジェスト機能を追加しました。入力中に候補が表示され、キーボード（上下キー、Enter）やクリックで選択できます。
- `GenreSection.svelte`: `trackStore.allGenres` を `BadgeField` に渡すようにし、ジャンルのサジェストを有効にしました。
- `package.json`: バージョンを `0.13.41` に更新しました。

### 検証内容
- `pnpm test`: 全テストパス
- `pnpm lint`: パス
- `pnpm build`: パス

### スクリーンショット（イメージ）
ジャンル入力時に、既存のトラックやデフォルトのジャンルから候補が表示されます。

Closes #83