### PR TITLE
fix: キーボードショートカットの不具合を修正 (Issue #96)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.47",
+  "version": "0.13.48",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/KeyboardShortcuts.svelte
+++ b/src/renderer/src/components/KeyboardShortcuts.svelte
@@ -15,14 +15,15 @@
     },
     {
       combo: { key: 's', ctrl: true },
-      handler: () => tagActions.saveAllModified()
+      handler: () => tagActions.saveAllModified(),
+      enabled: () => !uiState.isLoading
     },
     {
-      combo: { key: 'ArrowUp', alt: true },
+      combo: { key: 'ArrowUp' },
       handler: () => selectionState.selectPrevious(trackStore.tracks)
     },
     {
-      combo: { key: 'ArrowDown', alt: true },
+      combo: { key: 'ArrowDown' },
       handler: () => selectionState.selectNext(trackStore.tracks)
     }
   ];
@@ -30,9 +31,9 @@
   const handler = new KeyboardHandler(
     IS_MAC,
     rawActions.map((action) => ({
-      ...action,
       preventDefault: true,
-      enabled: () => !isInputFocused() && !uiState.isLoading
+      ...action,
+      enabled: action.enabled ?? (() => !isInputFocused() && !uiState.isLoading)
     }))
   );
 </script>

--- a/src/renderer/src/components/KeyboardShortcuts.svelte
+++ b/src/renderer/src/components/KeyboardShortcuts.svelte
@@ -1,17 +1,18 @@
 <script lang="ts">
+  import { tagActions } from '@renderer/services/tag-actions';
   import { selectionState } from '@renderer/stores/selection-state.svelte';
   import { trackStore } from '@renderer/stores/track-store.svelte';
   import { uiState } from '@renderer/stores/ui-state.svelte';
-  import { tagActions } from '@renderer/services/tag-actions';
   import { KeyboardHandler, type KeyboardAction } from '@renderer/utils/keyboard-handler';
 
-  import { isInputFocused } from '@renderer/utils/dom-utils';
   import { IS_MAC } from '@renderer/constants/platform';
+  import { isInputFocused } from '@renderer/utils/dom-utils';
 
   const rawActions: KeyboardAction[] = [
     {
       combo: { key: 'a', ctrl: true },
-      handler: () => selectionState.selectAll(trackStore.tracks)
+      handler: () => selectionState.selectAll(trackStore.tracks),
+      enabled: () => !isInputFocused() && !uiState.isLoading
     },
     {
       combo: { key: 's', ctrl: true },
@@ -20,11 +21,13 @@
     },
     {
       combo: { key: 'ArrowUp' },
-      handler: () => selectionState.selectPrevious(trackStore.tracks)
+      handler: () => selectionState.selectPrevious(trackStore.tracks),
+      enabled: () => !isInputFocused() && !uiState.isLoading
     },
     {
       combo: { key: 'ArrowDown' },
-      handler: () => selectionState.selectNext(trackStore.tracks)
+      handler: () => selectionState.selectNext(trackStore.tracks),
+      enabled: () => !isInputFocused() && !uiState.isLoading
     }
   ];
 
@@ -32,8 +35,7 @@
     IS_MAC,
     rawActions.map((action) => ({
       preventDefault: true,
-      ...action,
-      enabled: action.enabled ?? (() => !isInputFocused() && !uiState.isLoading)
+      ...action
     }))
   );
 </script>


### PR DESCRIPTION
Issue #96 の対応を行いました。

- 入力要素にフォーカスしている時でも ctrl + s で保存アクションが発火するように変更
- 矢印キーでの曲選択時に alt キーを不要に変更

ご確認のほどよろしくお願いいたします。