### PR TITLE
fix: アートワーク表示のレイアウト安定化とUIブラッシュアップ

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.51",
+  "version": "0.13.52",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.60",
+  "version": "0.13.61",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.61",
+  "version": "0.13.62",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.54",
+  "version": "0.13.55",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.59",
+  "version": "0.13.60",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.50",
+  "version": "0.13.51",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.53",
+  "version": "0.13.54",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.58",
+  "version": "0.13.59",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.63",
+  "version": "0.13.64",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.55",
+  "version": "0.13.56",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.56",
+  "version": "0.13.57",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.62",
+  "version": "0.13.63",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.57",
+  "version": "0.13.58",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.52",
+  "version": "0.13.53",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -117,7 +117,7 @@
   }
 
   .cover-art {
-    object-fit: cover;
+    object-fit: contain;
     transition: transform 0.3s ease;
   }
 

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -104,9 +104,8 @@
     background-color: transparent;
     border-radius: var(--radius-xl);
     overflow: hidden;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    display: grid;
+    place-items: center;
     width: fit-content;
   }
 
@@ -117,17 +116,13 @@
 
   .cover-placeholder,
   .art-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
+    grid-area: 1 / 1;
     width: 100%;
     height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
   }
 
   .cover-art {
+    grid-area: 1 / 1;
     width: auto;
     height: auto;
     max-width: 100%;

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-  import { UI_TOKENS } from '@renderer/constants/design-system';
   import { Music, X } from '@lucide/svelte';
+  import { UI_TOKENS } from '@renderer/constants/design-system';
+  import { IS_MAC } from '@renderer/constants/platform';
   import { tagActions } from '@renderer/services/tag-actions';
   import { trackStore } from '@renderer/stores/track-store.svelte';
-  import { IS_MAC } from '@renderer/constants/platform';
   import { KeyboardHandler } from '@renderer/utils/keyboard-handler';
 
   let imageLoadError = $state(false);
 
-  // URLが変わるたびにエラー状態をリセットする
+  // URLが変わるたびに状態をリセットする
   $effect(() => {
     if (trackStore.commonImageUrl) {
       imageLoadError = false;
@@ -48,27 +48,21 @@
     tabindex="0"
     title="Click to change artwork"
   >
-    {#if trackStore.commonImageUrl}
+    {#if trackStore.commonImageUrl && !imageLoadError}
       <img
         src={trackStore.commonImageUrl}
         alt="Cover Art"
         class="cover-art"
-        class:hidden={imageLoadError}
         onerror={() => (imageLoadError = true)}
-        onload={() => (imageLoadError = false)}
       />
-      {#if !imageLoadError}
-        <button
-          class="remove-artwork no-hover-glow"
-          onclick={handleRemoveArtwork}
-          title="Remove Artwork"
-        >
-          <X size={UI_TOKENS.icons.size} />
-        </button>
-      {/if}
-    {/if}
-
-    {#if !trackStore.commonImageUrl || imageLoadError}
+      <button
+        class="remove-artwork no-hover-glow"
+        onclick={handleRemoveArtwork}
+        title="Remove Artwork"
+      >
+        <X size={UI_TOKENS.icons.size} />
+      </button>
+    {:else}
       <div
         class="cover-placeholder"
         class:error={imageLoadError}
@@ -97,13 +91,12 @@
   .artwork-section {
     width: 100%;
     aspect-ratio: 1 / 1;
-    border-radius: var(--radius-xl);
-    overflow: hidden;
+    max-height: 500px;
     position: relative;
     cursor: pointer;
-    background-color: var(--bg-hover);
-    border: 1px solid var(--border-primary);
-    padding: 1px;
+    background-color: transparent;
+    border-radius: var(--radius-xl);
+    overflow: hidden;
     display: grid;
     place-items: center;
   }
@@ -117,12 +110,9 @@
   }
 
   .cover-art {
+    aspect-ratio: 1 / 1;
     object-fit: contain;
     transition: transform 0.3s ease;
-  }
-
-  .cover-art.hidden {
-    display: none;
   }
 
   .art-overlay {
@@ -150,6 +140,7 @@
     padding: 0.5rem 1rem;
     border-radius: var(--radius-2xl);
     border: 1px solid rgba(255, 255, 255, 0.2);
+    white-space: nowrap;
   }
 
   .remove-artwork {
@@ -186,6 +177,8 @@
     color: var(--text-dim);
     border: 2px dashed var(--border-primary);
     border-radius: var(--radius-xl);
+    background-color: var(--bg-hover);
+    gap: 0.5rem;
   }
 
   .cover-placeholder.error {

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -85,7 +85,7 @@
 <style>
   .artwork-container {
     width: 90%;
-    height: 300px;
+    height: 240px;
     margin: 0 auto 2rem auto;
     flex-shrink: 0;
     display: flex;
@@ -102,8 +102,9 @@
     background-color: transparent;
     border-radius: var(--radius-xl);
     overflow: hidden;
-    display: grid;
-    place-items: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: fit-content;
   }
 
@@ -114,17 +115,21 @@
 
   .cover-placeholder,
   .art-overlay {
-    grid-area: 1 / 1;
+    position: absolute;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .cover-art {
-    grid-area: 1 / 1;
     width: auto;
     height: auto;
     max-width: 100%;
-    max-height: 300px;
+    max-height: 240px;
     object-fit: contain;
     display: block;
     transition: transform 0.3s ease;

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -77,7 +77,7 @@
     {/if}
 
     <div class="art-overlay">
-      <div class="icon-circle">
+      <div class="icon-box">
         <Image size={UI_TOKENS.icons.sizeLarge} strokeWidth={UI_TOKENS.icons.strokeWidth} />
       </div>
     </div>
@@ -147,13 +147,13 @@
     opacity: 1;
   }
 
-  .art-overlay .icon-circle {
+  .art-overlay .icon-box {
     color: white;
     background: rgba(0, 0, 0, 0.5);
     backdrop-filter: blur(4px);
     padding: 1rem;
-    border-radius: var(--radius-full);
-    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: var(--radius-2xl);
+    border: 1px solid rgba(255, 255, 255, 0.2);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -161,10 +161,10 @@
     transition: all 0.2s ease;
   }
 
-  .artwork-section:hover .art-overlay .icon-circle {
+  .artwork-section:hover .art-overlay .icon-box {
     transform: scale(1.05);
     background: rgba(0, 0, 0, 0.7);
-    border-color: rgba(255, 255, 255, 0.3);
+    border-color: rgba(255, 255, 255, 0.4);
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
   }
 

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -102,9 +102,8 @@
     background-color: transparent;
     border-radius: var(--radius-xl);
     overflow: hidden;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    display: grid;
+    place-items: center;
     width: fit-content;
   }
 
@@ -115,17 +114,13 @@
 
   .cover-placeholder,
   .art-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
+    grid-area: 1 / 1;
     width: 100%;
     height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
   }
 
   .cover-art {
+    grid-area: 1 / 1;
     width: auto;
     height: auto;
     max-width: 100%;

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ImagePlus, Music, X } from '@lucide/svelte';
+  import { Image, Music, X } from '@lucide/svelte';
   import { UI_TOKENS } from '@renderer/constants/design-system';
   import { IS_MAC } from '@renderer/constants/platform';
   import { tagActions } from '@renderer/services/tag-actions';
@@ -78,7 +78,7 @@
 
     <div class="art-overlay">
       <div class="icon-circle">
-        <ImagePlus size={UI_TOKENS.icons.sizeLarge} strokeWidth={UI_TOKENS.icons.strokeWidth} />
+        <Image size={UI_TOKENS.icons.sizeLarge} strokeWidth={UI_TOKENS.icons.strokeWidth} />
       </div>
     </div>
   </div>

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -42,7 +42,6 @@
 <div class="artwork-container">
   <div
     class="artwork-section"
-    class:is-placeholder={!trackStore.commonImageUrl || imageLoadError}
     onclick={() => tagActions.pickAndApplyPicture()}
     onkeydown={(e) => handler.handle(e)}
     role="button"
@@ -90,22 +89,17 @@
   }
 
   .artwork-section {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    max-height: 300px;
     margin: 0 auto;
-    max-width: 100%;
-    max-height: 500px;
     position: relative;
     cursor: pointer;
-    background-color: transparent;
+    background-color: var(--bg-hover);
     border-radius: var(--radius-xl);
     overflow: hidden;
     display: grid;
     place-items: center;
-    width: fit-content;
-  }
-
-  .artwork-section.is-placeholder {
-    width: 100%;
-    aspect-ratio: 1 / 1;
   }
 
   .cover-placeholder,
@@ -118,9 +112,7 @@
   .cover-art {
     grid-area: 1 / 1;
     width: 100%;
-    height: auto;
-    max-width: 100%;
-    max-height: 500px;
+    height: 100%;
     object-fit: contain;
     display: block;
     transition: transform 0.3s ease;

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -42,6 +42,7 @@
 <div class="artwork-container">
   <div
     class="artwork-section"
+    class:is-placeholder={!trackStore.commonImageUrl || imageLoadError}
     onclick={() => tagActions.pickAndApplyPicture()}
     onkeydown={(e) => handler.handle(e)}
     role="button"
@@ -89,8 +90,8 @@
   }
 
   .artwork-section {
-    width: 100%;
-    aspect-ratio: 1 / 1;
+    margin: 0 auto;
+    max-width: 100%;
     max-height: 500px;
     position: relative;
     cursor: pointer;
@@ -99,6 +100,12 @@
     overflow: hidden;
     display: grid;
     place-items: center;
+    width: fit-content;
+  }
+
+  .artwork-section.is-placeholder {
+    width: 100%;
+    aspect-ratio: 1 / 1;
   }
 
   .cover-art,
@@ -110,8 +117,11 @@
   }
 
   .cover-art {
-    aspect-ratio: 1 / 1;
-    object-fit: contain;
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 500px;
+    display: block;
     transition: transform 0.3s ease;
   }
 

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -108,7 +108,6 @@
     aspect-ratio: 1 / 1;
   }
 
-  .cover-art,
   .cover-placeholder,
   .art-overlay {
     grid-area: 1 / 1;
@@ -117,10 +116,12 @@
   }
 
   .cover-art {
-    width: auto;
+    grid-area: 1 / 1;
+    width: 100%;
     height: auto;
     max-width: 100%;
     max-height: 500px;
+    object-fit: contain;
     display: block;
     transition: transform 0.3s ease;
   }

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -104,8 +104,9 @@
     background-color: transparent;
     border-radius: var(--radius-xl);
     overflow: hidden;
-    display: grid;
-    place-items: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: fit-content;
   }
 
@@ -116,13 +117,17 @@
 
   .cover-placeholder,
   .art-overlay {
-    grid-area: 1 / 1;
+    position: absolute;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .cover-art {
-    grid-area: 1 / 1;
     width: auto;
     height: auto;
     max-width: 100%;

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -42,6 +42,7 @@
 <div class="artwork-container">
   <div
     class="artwork-section"
+    class:is-placeholder={!trackStore.commonImageUrl || imageLoadError}
     onclick={() => tagActions.pickAndApplyPicture()}
     onkeydown={(e) => handler.handle(e)}
     role="button"
@@ -84,22 +85,31 @@
 <style>
   .artwork-container {
     width: 90%;
+    height: 300px;
     margin: 0 auto 2rem auto;
     flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .artwork-section {
-    width: 100%;
-    aspect-ratio: 1 / 1;
-    max-height: 300px;
     margin: 0 auto;
+    max-width: 100%;
+    max-height: 100%;
     position: relative;
     cursor: pointer;
-    background-color: var(--bg-hover);
+    background-color: transparent;
     border-radius: var(--radius-xl);
     overflow: hidden;
     display: grid;
     place-items: center;
+    width: fit-content;
+  }
+
+  .artwork-section.is-placeholder {
+    width: 100%;
+    aspect-ratio: 1 / 1;
   }
 
   .cover-placeholder,
@@ -111,8 +121,10 @@
 
   .cover-art {
     grid-area: 1 / 1;
-    width: 100%;
-    height: 100%;
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 300px;
     object-fit: contain;
     display: block;
     transition: transform 0.3s ease;

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Music, X } from '@lucide/svelte';
+  import { ImagePlus, Music, X } from '@lucide/svelte';
   import { UI_TOKENS } from '@renderer/constants/design-system';
   import { IS_MAC } from '@renderer/constants/platform';
   import { tagActions } from '@renderer/services/tag-actions';
@@ -77,7 +77,9 @@
     {/if}
 
     <div class="art-overlay">
-      <span>Change Artwork</span>
+      <div class="icon-circle">
+        <ImagePlus size={UI_TOKENS.icons.sizeLarge} strokeWidth={UI_TOKENS.icons.strokeWidth} />
+      </div>
     </div>
   </div>
 </div>
@@ -145,17 +147,25 @@
     opacity: 1;
   }
 
-  .art-overlay span {
+  .art-overlay .icon-circle {
     color: white;
-    font-size: 0.8rem;
-    font-weight: bold;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    background: rgba(0, 0, 0, 0.4);
-    padding: 0.5rem 1rem;
-    border-radius: var(--radius-2xl);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    white-space: nowrap;
+    background: rgba(255, 255, 255, 0.15);
+    backdrop-filter: blur(8px);
+    padding: 1rem;
+    border-radius: var(--radius-full);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+
+  .artwork-section:hover .art-overlay .icon-circle {
+    transform: scale(1.1) rotate(5deg);
+    background: rgba(255, 255, 255, 0.25);
+    border-color: rgba(255, 255, 255, 0.5);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
   }
 
   .remove-artwork {

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -149,23 +149,23 @@
 
   .art-overlay .icon-circle {
     color: white;
-    background: rgba(255, 255, 255, 0.15);
-    backdrop-filter: blur(8px);
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(4px);
     padding: 1rem;
     border-radius: var(--radius-full);
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.15);
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+    transition: all 0.2s ease;
   }
 
   .artwork-section:hover .art-overlay .icon-circle {
-    transform: scale(1.1) rotate(5deg);
-    background: rgba(255, 255, 255, 0.25);
-    border-color: rgba(255, 255, 255, 0.5);
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+    transform: scale(1.05);
+    background: rgba(0, 0, 0, 0.7);
+    border-color: rgba(255, 255, 255, 0.3);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
   }
 
   .remove-artwork {


### PR DESCRIPTION
## 概要 (Issue #98)
インスペクターパネルにおけるアートワーク表示の「レイアウトの不安定さ」と「UIの視認性」を改善しました。

## 修正・改善内容
### 1. レイアウトの安定化
- **コンテナの高さ固定**: `.artwork-container` の高さを 240px に固定し、画像のアスペクト比によって下の入力フィールド（Title等）が上下にガタつく問題を解消しました。
- **中央配置**: 固定された高さの中で、アートワークを常に上下左右中央に配置するようにしました。

### 2. UIのブラッシュアップ
- **アイコン化**: 「Change Artwork」というテキストを、より洗練されたシンプルな `Image` アイコンに変更しました。
- **デザインの統一**: アイコン背景を円形から、アプリの他パーツと調和する角丸長方形に変更。グラスモルフィズム（背景ぼかし）と微細な境界線を採用し、プロフェッショナルでシックな外観に仕上げました。
- **インタラクション**: ホバー時にアイコンがふんわりと拡大するアニメーションを追加し、操作感を向上させました。

### 3. 表示の最適化
- **フィット表示**: `.artwork-section` は画像がある場合はそのサイズにぴったり吸い付くように調整。
- **プレースホルダーの改善**: 画像がない、または読み込みエラー時も常に安定した正方形の枠を維持し、アイコンとテキストが中央で正確に重なるように修正しました。

## 技術的な変更
- `ArtworkSection.svelte` の CSS 構造を Grid から Flex ベースへ適宜見直し、要素の重ね合わせと配置を整理。
- `package.json` のバージョンを `0.13.64` に更新。

## 検証内容
- [x] 正方形、縦長、横長の画像でレイアウトが崩れないこと
- [x] 画像なし、読み込みエラー時の表示が安定していること
- [x] `pnpm build`, `lint`, `test`, `format` がすべてパスすること