### PR TITLE
style: アートワークホバー時のアイコン背景色を明るく調整

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.65",
+  "version": "0.13.66",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/inspector/ArtworkSection.svelte
+++ b/src/renderer/src/components/inspector/ArtworkSection.svelte
@@ -133,7 +133,7 @@
   }
 
   .art-overlay {
-    background: rgba(0, 0, 0, 0.4);
+    background: rgba(0, 0, 0, 0.25);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -149,7 +149,7 @@
 
   .art-overlay .icon-box {
     color: white;
-    background: rgba(0, 0, 0, 0.5);
+    background: rgba(0, 0, 0, 0.35);
     backdrop-filter: blur(4px);
     padding: 1rem;
     border-radius: var(--radius-2xl);
@@ -163,7 +163,7 @@
 
   .artwork-section:hover .art-overlay .icon-box {
     transform: scale(1.05);
-    background: rgba(0, 0, 0, 0.7);
+    background: rgba(0, 0, 0, 0.5);
     border-color: rgba(255, 255, 255, 0.4);
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
   }


### PR DESCRIPTION
アートワークにホバーした際に表示されるアイコンの背景色が「少し濃い」というフィードバックに基づき、以下の調整を行いました。

### 変更内容
- アートワーク全体のオーバーレイ背景の透明度を調整 (`0.4` → `0.25`)
- アイコンボックスの背景色の透明度を調整 (`0.5` → `0.35`)
- ホバー時のアイコンボックス背景色の透明度を調整 (`0.7` → `0.5`)

これにより、背景の画像がより透けて見えつつ、アイコンの視認性も確保したバランスに修正しました。

### 検証内容
- `pnpm build`: 正常終了
- `pnpm lint`: 正常終了
- `pnpm format`: 正常終了