### PR TITLE
refactor: UiStateのプロパティをプライベート化しカプセル化を強化 (#105)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.67",
+  "version": "0.13.68",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/renderer/src/stores/ui-state.svelte.ts
+++ b/src/renderer/src/stores/ui-state.svelte.ts
@@ -6,34 +6,46 @@ import { formatTagError } from '@renderer/utils/tag-error-formatter';
  * アプリケーション全体の通知・ステータスメッセージを管理するストア。
  */
 class UiState {
-  error = $state<string | null>(null);
-  isLoading = $state(false);
-  isScanLimited = $state(false);
+  #error = $state<string | null>(null);
+  #isLoading = $state(false);
+  #isScanLimited = $state(false);
+
+  get error(): string | null {
+    return this.#error;
+  }
+
+  get isLoading(): boolean {
+    return this.#isLoading;
+  }
+
+  get isScanLimited(): boolean {
+    return this.#isScanLimited;
+  }
 
   startLoading(): void {
-    this.isLoading = true;
+    this.#isLoading = true;
   }
 
   stopLoading(): void {
-    this.isLoading = false;
+    this.#isLoading = false;
   }
 
   setError(item: Failure<TagError>): void {
-    this.error = formatTagError(item.error);
+    this.#error = formatTagError(item.error);
   }
 
   /**
    * 現在表示されているエラーメッセージを消去します。
    */
   clearError(): void {
-    this.error = null;
+    this.#error = null;
   }
 
   /**
    * スキャンの件数制限に達したかどうかのフラグを更新します。
    */
   setScanLimited(limited: boolean): void {
-    this.isScanLimited = limited;
+    this.#isScanLimited = limited;
   }
 
   /**
@@ -42,7 +54,7 @@ class UiState {
   reset(): void {
     this.clearError();
     this.stopLoading();
-    this.isScanLimited = false;
+    this.#isScanLimited = false;
   }
 }
 

--- a/src/renderer/src/stores/ui-state.test.ts
+++ b/src/renderer/src/stores/ui-state.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { uiState } from './ui-state.svelte';
+import { failure } from '@domain/common/result';
+import type { TagError } from '@domain/flac/types';
+
+describe('UiState', () => {
+  beforeEach(() => {
+    uiState.reset();
+  });
+
+  it('初期状態が正しいこと', () => {
+    expect(uiState.error).toBeNull();
+    expect(uiState.isLoading).toBe(false);
+    expect(uiState.isScanLimited).toBe(false);
+  });
+
+  it('startLoading で isLoading が true になること', () => {
+    uiState.startLoading();
+    expect(uiState.isLoading).toBe(true);
+  });
+
+  it('stopLoading で isLoading が false になること', () => {
+    uiState.startLoading();
+    uiState.stopLoading();
+    expect(uiState.isLoading).toBe(false);
+  });
+
+  it('setError でエラーメッセージが設定されること', () => {
+    const error: TagError = {
+      type: 'PARSE_FAILED',
+      options: { path: 'test.flac', detail: 'custom message' }
+    };
+    uiState.setError(failure(error));
+    expect(uiState.error).toBe('Failed to parse file: custom message');
+  });
+
+  it('clearError でエラーメッセージが消去されること', () => {
+    const error: TagError = {
+      type: 'PARSE_FAILED',
+      options: { path: 'test.flac', detail: 'test error' }
+    };
+    uiState.setError(failure(error));
+    uiState.clearError();
+    expect(uiState.error).toBeNull();
+  });
+
+  it('setScanLimited で isScanLimited が更新されること', () => {
+    uiState.setScanLimited(true);
+    expect(uiState.isScanLimited).toBe(true);
+    uiState.setScanLimited(false);
+    expect(uiState.isScanLimited).toBe(false);
+  });
+
+  it('reset で全ての状態が初期化されること', () => {
+    uiState.startLoading();
+    uiState.setError(failure({ type: 'PARSE_FAILED', options: { path: '', detail: 'error' } }));
+    uiState.setScanLimited(true);
+
+    uiState.reset();
+
+    expect(uiState.error).toBeNull();
+    expect(uiState.isLoading).toBe(false);
+    expect(uiState.isScanLimited).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要
Issue #105 に基づき、`UiState` ストアのプロパティを外部から直接変更できないようにカプセル化を強化しました。

## 変更内容
- `src/renderer/src/stores/ui-state.svelte.ts`
    - `error`, `isLoading`, `isScanLimited` をプライベートフィールド (`#`) に変更
    - 外部からの読み取り用にゲッターを追加
    - クラス内メソッドからのアクセスをプライベートフィールド経由に修正
- `src/renderer/src/stores/ui-state.test.ts` (新規)
    - `UiState` の各メソッドによる状態遷移と `reset` 機能のユニットテストを追加

## 検証内容
- `pnpm test`: 全テストパス (新規追加分を含む)
- `pnpm lint`: エラーなし
- `pnpm build`: 正常終了
- `pnpm typecheck`: 正常終了

## 備考
- `package.json` のバージョンを `0.13.68` に更新しました。

Closes #105