### PR TITLE
fix: dependencies の整理とバンドル設定の修正 (#90)

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,9 +1,20 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-import { defineConfig } from 'electron-vite';
+import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 import { resolve } from 'path';
 
 export default defineConfig({
   main: {
+    plugins: [
+      externalizeDepsPlugin({
+        exclude: [
+          'flac-tagger',
+          'music-metadata',
+          'fast-equals',
+          'electron-updater',
+          '@electron-toolkit/utils'
+        ]
+      })
+    ],
     resolve: {
       alias: {
         '@shared': resolve('src/shared'),
@@ -16,6 +27,7 @@ export default defineConfig({
     }
   },
   preload: {
+    plugins: [externalizeDepsPlugin()],
     resolve: {
       alias: {
         '@shared': resolve('src/shared'),

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,11 +1,11 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
+import { defineConfig } from 'electron-vite';
 import { resolve } from 'path';
 
 export default defineConfig({
   main: {
-    plugins: [
-      externalizeDepsPlugin({
+    build: {
+      externalizeDeps: {
         exclude: [
           'flac-tagger',
           'music-metadata',
@@ -13,8 +13,8 @@ export default defineConfig({
           'electron-updater',
           '@electron-toolkit/utils'
         ]
-      })
-    ],
+      }
+    },
     resolve: {
       alias: {
         '@shared': resolve('src/shared'),
@@ -27,7 +27,6 @@ export default defineConfig({
     }
   },
   preload: {
-    plugins: [externalizeDepsPlugin()],
     resolve: {
       alias: {
         '@shared': resolve('src/shared'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.69",
+  "version": "0.13.70",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.13.68",
+  "version": "0.13.69",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",
@@ -43,12 +43,18 @@
     "test": "vitest run --coverage",
     "release": "pnpm version patch && git push origin main --follow-tags"
   },
+  "dependencies": {
+    "@electron-toolkit/utils": "^4.0.0",
+    "electron-updater": "^6.8.3",
+    "fast-equals": "^6.0.0",
+    "flac-tagger": "^2.0.0",
+    "music-metadata": "^11.12.3"
+  },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",
     "@electron-toolkit/eslint-config-ts": "^3.1.0",
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/tsconfig": "^2.0.0",
-    "@electron-toolkit/utils": "^4.0.0",
     "@lucide/svelte": "^1.9.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.0",
     "@types/node": "^25.6.0",
@@ -56,15 +62,11 @@
     "dotenv-cli": "^11.0.0",
     "electron": "^41.3.0",
     "electron-builder": "^26.0.12",
-    "electron-updater": "^6.8.3",
     "electron-vite": "^5.0.0",
     "eslint": "^10.2.1",
     "eslint-plugin-svelte": "^3.17.1",
-    "fast-equals": "^6.0.0",
-    "flac-tagger": "^2.0.0",
     "jsdom": "^29.0.2",
     "license-checker-rseidelsohn": "^4.4.2",
-    "music-metadata": "^11.12.3",
     "prettier": "^3.8.3",
     "prettier-plugin-svelte": "^3.4.0",
     "svelte": "^5.55.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,22 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@electron-toolkit/utils':
+        specifier: ^4.0.0
+        version: 4.0.0(electron@41.3.0)
+      electron-updater:
+        specifier: ^6.8.3
+        version: 6.8.3
+      fast-equals:
+        specifier: ^6.0.0
+        version: 6.0.0
+      flac-tagger:
+        specifier: ^2.0.0
+        version: 2.0.0
+      music-metadata:
+        specifier: ^11.12.3
+        version: 11.12.3
     devDependencies:
       '@electron-toolkit/eslint-config-prettier':
         specifier: ^3.0.0
@@ -20,9 +36,6 @@ importers:
       '@electron-toolkit/tsconfig':
         specifier: ^2.0.0
         version: 2.0.0(@types/node@25.6.0)
-      '@electron-toolkit/utils':
-        specifier: ^4.0.0
-        version: 4.0.0(electron@41.3.0)
       '@lucide/svelte':
         specifier: ^1.9.0
         version: 1.9.0(svelte@5.55.5(@typescript-eslint/types@8.58.0))
@@ -44,9 +57,6 @@ importers:
       electron-builder:
         specifier: ^26.0.12
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
-      electron-updater:
-        specifier: ^6.8.3
-        version: 6.8.3
       electron-vite:
         specifier: ^5.0.0
         version: 5.0.0(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1))
@@ -56,21 +66,12 @@ importers:
       eslint-plugin-svelte:
         specifier: ^3.17.1
         version: 3.17.1(eslint@10.2.1(jiti@2.6.1))(svelte@5.55.5(@typescript-eslint/types@8.58.0))
-      fast-equals:
-        specifier: ^6.0.0
-        version: 6.0.0
-      flac-tagger:
-        specifier: ^2.0.0
-        version: 2.0.0
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2
       license-checker-rseidelsohn:
         specifier: ^4.4.2
         version: 4.4.2
-      music-metadata:
-        specifier: ^11.12.3
-        version: 11.12.3
       prettier:
         specifier: ^3.8.3
         version: 3.8.3


### PR DESCRIPTION
## 概要
GitHub Issue #90 の対応を行いました。

### 課題
`flac-tagger` や `music-metadata` などのランタイム依存パッケージを `devDependencies` から `dependencies` へ移動すると、ビルド後のアプリが実機で起動しなくなる。
これは `electron-vite` のデフォルト挙動により、`dependencies` に含まれるパッケージが外部依存（external）として扱われ、バンドルから除外されるためです。パッケージング時に `node_modules` の構造が正しく維持されない（特に pnpm 使用時）と、実行時にこれらのライブラリが見つからずエラーとなります。

### 解決策
1. **dependencies の整理**: ランタイムに必要なパッケージを `dependencies` へ移動しました。
2. **バンドル設定の修正**: `electron.vite.config.ts` に `externalizeDepsPlugin` を導入し、ランタイムパッケージをバンドル対象（exclude）に指定しました。これにより、以前と同様に `out/main/index.js` にライブラリが同梱されるようになり、実機での起動エラーが解消されます。

### 実施内容
- `package.json` の更新（dependencies への移動、バージョンアップ 0.13.69）
- `electron.vite.config.ts` の更新（バンドル設定の追加）
- `pnpm install` による `pnpm-lock.yaml` の更新
- `pnpm build` によるビルド成功の確認

### 検証内容
- [x] `pnpm install` が正常に完了すること
- [x] `pnpm build` が成功し、`out/main/index.js` にパーサー類がバンドルされていることを確認
- [x] `pnpm lint` および `pnpm format` をパスすること