### PR TITLE
fix: ログ領域の横幅拡大によるレイアウト崩れの修正とインスペクターの最小幅設定

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -45,5 +45,6 @@
     border-right: 1px solid #333;
     overflow: clip;
     min-height: 0;
+    min-width: 0;
   }
 </style>

--- a/src/renderer/src/components/Inspector.svelte
+++ b/src/renderer/src/components/Inspector.svelte
@@ -54,6 +54,7 @@
 <style>
   .inspector {
     width: 320px;
+    min-width: 320px;
     background-color: var(--bg-inspector);
     display: flex;
     flex-direction: column;

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -215,6 +215,8 @@
     line-height: 1.5;
     padding: 0.1rem 0.4rem;
     border-radius: 2px;
+    width: fit-content;
+    min-width: 100%;
   }
 
   .log-entry:hover {
@@ -247,8 +249,6 @@
   .log-text {
     color: var(--text-secondary);
     white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
     flex: 1;
   }
 </style>


### PR DESCRIPTION
GitHub Issue #120 に対する修正です。

### 修正内容
1.  **レイアウト崩れの修正 (`App.svelte`)**: ログ領域に長いメッセージが表示された際に、メインコンテンツ領域が横に拡大してインスペクターを押し出してしまう問題を修正しました。`.main-content` に `min-width: 0` を設定することで、flexbox 内での不要な拡大を抑制しています。
2.  **ログ表示の改善 (`StatusBar.svelte`)**:
    *   ログ項目の省略表示（ellipsis）を解除し、長いメッセージも全文保持するようにしました。
    *   `width: fit-content` と `min-width: 100%` を設定することで、親のスクロール領域内で適切に横スクロールできるようにしました。
3.  **インスペクターの最小幅設定 (`Inspector.svelte`)**: ウィンドウ幅が狭い場合でもインスペクターが潰れないよう、`min-width: 320px` を設定しました。

### 検証内容
- [x] `pnpm lint` パス
- [x] `pnpm test` 全テスト（179件）パス
- [x] `pnpm build` 正常終了

Close #120