### PR TITLE
fix: ログのスクロールハイジャック対策を削除 #119

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.14.5",
+  "version": "0.14.4",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -7,8 +7,7 @@
   import { KeyboardHandler } from '@renderer/utils/keyboard-handler';
   import { formatLogTime } from '@shared/utils/date';
   import type { Component } from 'svelte';
-  import { flip } from 'svelte/animate';
-  import { fade, slide } from 'svelte/transition';
+  import { slide } from 'svelte/transition';
 
   const levelIcons: ReadonlyMap<LogLevel, Component<LucideProps>> = new Map([
     ['INFO', Info],
@@ -79,11 +78,7 @@
       <div class="log-list" bind:this={logListElement}>
         {#each logStore.logs as log (log.id)}
           {@const ICON = levelIcons.get(log.level)}
-          <div
-            class="log-entry {log.level}"
-            transition:fade={{ duration: 200 }}
-            animate:flip={{ duration: 200 }}
-          >
+          <div class="log-entry {log.level}">
             <span class="log-time">[{formatLogTime(log.timestamp)}]</span>
             <div class="log-level-icon">
               <ICON size={UI_TOKENS.icons.sizeSmall} />

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -7,7 +7,8 @@
   import { KeyboardHandler } from '@renderer/utils/keyboard-handler';
   import { formatLogTime } from '@shared/utils/date';
   import type { Component } from 'svelte';
-  import { slide } from 'svelte/transition';
+  import { flip } from 'svelte/animate';
+  import { fly, slide } from 'svelte/transition';
 
   const levelIcons: ReadonlyMap<LogLevel, Component<LucideProps>> = new Map([
     ['INFO', Info],
@@ -15,11 +16,8 @@
     ['ERROR', CircleAlert]
   ] as const);
 
-  const SCROLL_THRESHOLD_PX = 50;
-
   let isExpanded = $state(false);
   let logListElement: HTMLDivElement | undefined = $state();
-  let isAtBottom = $state(true);
 
   const toggleExpand = (): void => {
     isExpanded = !isExpanded;
@@ -30,26 +28,15 @@
   /** メインバーに表示する現在の状態 */
   const displayState = $derived(logStore.latestLog);
 
-  // スクロールハイジャック対策
-  $effect.pre(() => {
-    if (!logListElement || logStore.logs.length < 0) {
-      return;
-    }
-
-    const { scrollTop, scrollHeight, clientHeight } = logListElement;
-    // 下端付近にいるなら追従対象とする
-    isAtBottom = scrollHeight - scrollTop - clientHeight < SCROLL_THRESHOLD_PX;
-  });
-
-  // ログが追加された後、下端にいた場合のみスクロールを追従させる
+  // ログが追加された後、スクロールを追従させる
   $effect(() => {
     // 前提条件：要素が存在し、かつ展開されていること
     if (!logListElement || !isExpanded) {
       return;
     }
 
-    // 実行条件：下端にいない、または表示するログが存在しない場合は終了
-    if (!isAtBottom || logStore.logs.length === 0) {
+    // 実行条件：表示するログが存在しない場合は終了
+    if (logStore.logs.length === 0) {
       return;
     }
 
@@ -92,7 +79,11 @@
       <div class="log-list" bind:this={logListElement}>
         {#each logStore.logs as log (log.id)}
           {@const ICON = levelIcons.get(log.level)}
-          <div class="log-entry {log.level}">
+          <div
+            class="log-entry {log.level}"
+            transition:fly={{ y: 10, duration: 200 }}
+            animate:flip={{ duration: 200 }}
+          >
             <span class="log-time">[{formatLogTime(log.timestamp)}]</span>
             <div class="log-level-icon">
               <ICON size={UI_TOKENS.icons.sizeSmall} />

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -8,7 +8,7 @@
   import { formatLogTime } from '@shared/utils/date';
   import type { Component } from 'svelte';
   import { flip } from 'svelte/animate';
-  import { fly, slide } from 'svelte/transition';
+  import { fade, slide } from 'svelte/transition';
 
   const levelIcons: ReadonlyMap<LogLevel, Component<LucideProps>> = new Map([
     ['INFO', Info],
@@ -81,7 +81,7 @@
           {@const ICON = levelIcons.get(log.level)}
           <div
             class="log-entry {log.level}"
-            transition:fly={{ y: 10, duration: 200 }}
+            transition:fade={{ duration: 200 }}
             animate:flip={{ duration: 200 }}
           >
             <span class="log-time">[{formatLogTime(log.timestamp)}]</span>


### PR DESCRIPTION
## 概要
GitHub issue #119 に対応しました。
ログのスクロールハイジャック対策を削除し、ログ追加時に常に最新の状態へスクロールするように修正しました。

## 変更内容
- `StatusBar.svelte`
  - ログのスクロールハイジャック対策（50pxの閾値判定）を削除しました。これにより、ログが追加された際は常に最新のログまで自動スクロールされます。
- `package.json`
  - バージョンを `0.14.4` に更新しました。

## 検証内容
- `pnpm format`, `pnpm lint`, `pnpm test` がパスすることを確認しました。
- `pnpm build` が正常に完了することを確認しました。