### PR TITLE
feat: Ctrl+O (Cmd+O) ショートカットの追加 (#124)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/KeyboardShortcuts.svelte
+++ b/src/renderer/src/components/KeyboardShortcuts.svelte
@@ -15,6 +15,11 @@
       enabled: () => !isInputFocused() && !uiState.isLoading
     },
     {
+      combo: { key: 'o', ctrl: true },
+      handler: () => tagActions.openAndScanDirectory(),
+      enabled: () => !uiState.isLoading
+    },
+    {
       combo: { key: 's', ctrl: true },
       handler: () => tagActions.saveAllModified(),
       enabled: () => !uiState.isLoading

--- a/src/renderer/src/utils/keyboard-types.ts
+++ b/src/renderer/src/utils/keyboard-types.ts
@@ -1,4 +1,4 @@
 /**
  * アプリ内で実際に使用されているキー名を定義します。
  */
-export type KeyboardKey = 'ArrowUp' | 'ArrowDown' | 'Enter' | 'Backspace' | ',' | 'a' | 's';
+export type KeyboardKey = 'ArrowUp' | 'ArrowDown' | 'Enter' | 'Backspace' | ',' | 'a' | 's' | 'o';


### PR DESCRIPTION
## 概要
ディレクトリを開くためのキーボードショートカット `Ctrl+O`（Macの場合は `Cmd+O`）を追加しました。

## 変更内容
- `src/renderer/src/utils/keyboard-types.ts`: `KeyboardKey` 型に `'o'` を追加
- `src/renderer/src/components/KeyboardShortcuts.svelte`: `Ctrl+O` ショートカットを登録し、`tagActions.openAndScanDirectory` と紐付け
- `package.json`: バージョンを `0.14.5` に更新

## 検証内容
- `pnpm typecheck`: パス
- `pnpm test`: すべてのテストがパス
- `pnpm build`: 正常にビルド可能
