### PR TITLE
refactor: パス生成処理のメインプロセス集約とUI改善 (#117)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/main/ipc/flac-handlers.ts
+++ b/src/main/ipc/flac-handlers.ts
@@ -2,7 +2,7 @@ import { FlacTrack } from '@domain/flac/types';
 import { withResultLogging } from '@main/infrastructure/logging/result-logging';
 import { getImageInfo, pickImage } from '@services/flac/image';
 import { readMetadata } from '@services/flac/reader';
-import { renameFile } from '@services/flac/renamer';
+import { renameFile, resolveRenamedPath } from '@services/flac/renamer';
 import { scanDirectory } from '@services/flac/scanner';
 import { writeMetadata } from '@services/flac/writer';
 import { IPC_CHANNELS } from '@shared/ipc';
@@ -46,6 +46,15 @@ export const registerFlacHandlers = (): void => {
       () => renameFile(oldPath, newPath),
       oldPath,
       newPath
+    );
+  });
+
+  // 新しいパスの生成
+  ipcMain.handle(IPC_CHANNELS.GENERATE_NEW_PATH, async (_event, track: FlacTrack) => {
+    return withResultLogging(
+      IPC_CHANNELS.GENERATE_NEW_PATH,
+      async () => resolveRenamedPath(track),
+      track.path
     );
   });
 };

--- a/src/main/ipc/platform-handlers.ts
+++ b/src/main/ipc/platform-handlers.ts
@@ -1,5 +1,4 @@
 import { selectDirectory } from '@services/platform/dialog';
-import { getDirname, joinPaths } from '@services/platform/path';
 import { getPlatform } from '@services/platform/platform';
 import { IPC_CHANNELS } from '@shared/ipc';
 import { ipcMain } from 'electron';
@@ -16,15 +15,5 @@ export const registerPlatformHandlers = (): void => {
   // プラットフォームを取得
   ipcMain.handle(IPC_CHANNELS.GET_PLATFORM, () => {
     return getPlatform();
-  });
-
-  // ディレクトリ名を取得
-  ipcMain.handle(IPC_CHANNELS.PATH_DIRNAME, (_event, p: string) => {
-    return getDirname(p);
-  });
-
-  // パスを結合
-  ipcMain.handle(IPC_CHANNELS.PATH_JOIN, (_event, ...paths: string[]) => {
-    return joinPaths(...paths);
   });
 };

--- a/src/main/services/flac/renamer.ts
+++ b/src/main/services/flac/renamer.ts
@@ -1,5 +1,7 @@
 import { success } from '@domain/common/result';
-import { tagErrors, TagResult } from '@domain/flac/types';
+import { tagErrors, TagResult, type FlacTrack } from '@domain/flac/types';
+import { formatFlacFilename } from '@domain/flac/filename-formatter';
+import path from 'path';
 import fs from 'fs/promises';
 import { toTagResultFailure } from '@main/utils/error-handler';
 import { ensureFileExists } from '@main/utils/fs';
@@ -25,6 +27,20 @@ export const renameFile = async (oldPath: string, newPath: string): Promise<TagR
   }
 
   return success(undefined);
+};
+
+/**
+ * トラックのメタデータに基づいて、リネーム後のフルパスを算出します。
+ * @param track トラック情報
+ */
+export const resolveRenamedPath = (track: FlacTrack): TagResult<string> => {
+  const filenameResult = formatFlacFilename(track);
+  if (filenameResult.type === 'error') {
+    return filenameResult;
+  }
+  const dir = path.dirname(track.path);
+  const newPath = path.join(dir, filenameResult.value);
+  return success(newPath);
 };
 
 /**

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -47,17 +47,15 @@ export const api: IpcApi = {
   renameFile: (oldPath: string, newPath: string) =>
     ipcRenderer.invoke(IPC_CHANNELS.RENAME_FILE, oldPath, newPath),
   /**
+   * メタデータに基づいて新しいファイルパスを生成します。
+   * @param track トラック情報
+   */
+  generateNewPath: (track: FlacTrack) => ipcRenderer.invoke(IPC_CHANNELS.GENERATE_NEW_PATH, track),
+  /**
    * File オブジェクトから OS 上のファイルシステムパスを取得します。
    * Electron v28+ で非推奨となった File.path の代替です。
    */
   getPathForFile: (file: File) => webUtils.getPathForFile(file),
-  /**
-   * パス操作（メインプロセス経由）。
-   */
-  path: {
-    dirname: (p: string) => ipcRenderer.invoke(IPC_CHANNELS.PATH_DIRNAME, p),
-    join: (...paths: string[]) => ipcRenderer.invoke(IPC_CHANNELS.PATH_JOIN, ...paths)
-  },
   getPlatform: () => ipcRenderer.invoke(IPC_CHANNELS.GET_PLATFORM),
   /**
    * ログメッセージを受信した時のコールバックを登録します。

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -6,7 +6,7 @@
   import { logStore } from '@renderer/stores/log-store.svelte';
   import { KeyboardHandler } from '@renderer/utils/keyboard-handler';
   import { formatLogTime } from '@shared/utils/date';
-  import type { Component } from 'svelte';
+  import { onDestroy, type Component } from 'svelte';
   import { slide } from 'svelte/transition';
 
   const levelIcons: ReadonlyMap<LogLevel, Component<LucideProps>> = new Map([
@@ -17,6 +17,18 @@
 
   let isExpanded = $state(false);
   let logListElement: HTMLDivElement | undefined = $state();
+
+  // ログが最初に1件以上になった時、自動で展開する
+  const stopAutoExpand = $effect.root(() => {
+    $effect(() => {
+      if (logStore.logs.length === 0) {
+        return;
+      }
+      isExpanded = true;
+      stopAutoExpand();
+    });
+  });
+  onDestroy(stopAutoExpand);
 
   const toggleExpand = (): void => {
     isExpanded = !isExpanded;

--- a/src/renderer/src/infrastructure/adapters/path-adapter.test.ts
+++ b/src/renderer/src/infrastructure/adapters/path-adapter.test.ts
@@ -1,40 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getDirectoryName, joinPath } from './path-adapter';
+import { generateNewPath } from './path-adapter';
+import { success } from '@domain/common/result';
+import type { FlacTrack } from '@domain/flac/types';
 
 describe('path-adapter', () => {
   beforeEach(() => {
     vi.stubGlobal('window', {
       api: {
-        path: {
-          dirname: vi.fn(),
-          join: vi.fn()
-        }
+        generateNewPath: vi.fn()
       }
     });
   });
 
-  describe('getDirectoryName', () => {
-    it('window.api.path.dirname を呼び出すこと', async () => {
-      const path = '/path/to/file.txt';
-      vi.mocked(window.api.path.dirname).mockResolvedValue('/path/to');
+  describe('generateNewPath', () => {
+    it('window.api.generateNewPath を呼び出すこと', async () => {
+      const track = { path: '/dir/old.flac', metadata: { title: 'T', trackNumber: 1 } };
+      const expected = success('/dir/01 - T.flac');
+      vi.stubGlobal('window', {
+        api: {
+          generateNewPath: vi.fn().mockResolvedValue(expected)
+        }
+      });
 
-      const result = await getDirectoryName(path);
+      const result = await generateNewPath(track as unknown as FlacTrack);
 
-      expect(result).toBe('/path/to');
-      expect(window.api.path.dirname).toHaveBeenCalledWith(path);
-    });
-  });
-
-  describe('joinPath', () => {
-    it('window.api.path.join を呼び出すこと', async () => {
-      const dir = '/path/to';
-      const filename = 'file.txt';
-      vi.mocked(window.api.path.join).mockResolvedValue('/path/to/file.txt');
-
-      const result = await joinPath(dir, filename);
-
-      expect(result).toBe('/path/to/file.txt');
-      expect(window.api.path.join).toHaveBeenCalledWith(dir, filename);
+      expect(result).toBe(expected);
+      expect(window.api.generateNewPath).toHaveBeenCalledWith(track);
     });
   });
 });

--- a/src/renderer/src/infrastructure/adapters/path-adapter.ts
+++ b/src/renderer/src/infrastructure/adapters/path-adapter.ts
@@ -1,22 +1,14 @@
+import type { FlacTrack, TagResult } from '@domain/flac/types';
+
 /**
  * Electron/Node.jsのパス操作APIをRendererプロセスから利用するためのアダプター。
  */
 
 /**
- * フルパスからディレクトリ名を抽出します。
- * @param path 対象のフルパス
- * @returns ディレクトリパス
+ * メタデータに基づいて新しいファイルパスを生成します。
+ * @param track トラック情報
+ * @returns 生成された新しいフルパス
  */
-export const getDirectoryName = async (path: string): Promise<string> => {
-  return await window.api.path.dirname(path);
-};
-
-/**
- * ディレクトリパスとファイル名を結合します。
- * @param dir ディレクトリパス
- * @param filename ファイル名
- * @returns 結合されたフルパス
- */
-export const joinPath = async (dir: string, filename: string): Promise<string> => {
-  return await window.api.path.join(dir, filename);
+export const generateNewPath = async (track: FlacTrack): Promise<TagResult<string>> => {
+  return await window.api.generateNewPath(track);
 };

--- a/src/renderer/src/services/file-actions.test.ts
+++ b/src/renderer/src/services/file-actions.test.ts
@@ -7,11 +7,8 @@ import { tagRepository } from '@renderer/infrastructure/repositories/tag-reposit
 import { fileRepository } from '@renderer/infrastructure/repositories/file-repository';
 import { success, failure } from '@domain/common/result';
 import { TrackRecord } from '@renderer/stores/track-record.svelte';
-import type { FlacMetadata, FlacTrack } from '@domain/flac/types';
-import { logStore } from '@renderer/stores/log-store.svelte';
-
+import { tagErrors, type FlacMetadata, type FlacTrack } from '@domain/flac/types';
 import * as pathAdapter from '@renderer/infrastructure/adapters/path-adapter';
-import * as formatter from '@domain/flac/filename-formatter';
 
 describe('fileActions', () => {
   beforeEach(() => {
@@ -21,11 +18,12 @@ describe('fileActions', () => {
     selectionState.items.clear();
     vi.spyOn(tagRepository, 'readMetadata');
     vi.spyOn(fileRepository, 'renameFile');
-    vi.spyOn(pathAdapter, 'getDirectoryName').mockReturnValue(Promise.resolve('/dir'));
-    vi.spyOn(pathAdapter, 'joinPath').mockImplementation((dir, file) =>
-      Promise.resolve(`${dir}/${file}`)
-    );
-    vi.spyOn(formatter, 'formatFlacFilename').mockReturnValue(success('new.flac'));
+    vi.spyOn(pathAdapter, 'generateNewPath').mockResolvedValue(success('/dir/new.flac'));
+    vi.stubGlobal('window', {
+      api: {
+        generateNewPath: vi.fn().mockResolvedValue(success('/dir/new.flac'))
+      }
+    });
   });
 
   describe('renameSelectedFiles', () => {
@@ -56,19 +54,18 @@ describe('fileActions', () => {
       expect(selectionState.items.size).toBe(0);
     });
 
-    it('ファイル名生成（レンダラー側処理）に失敗した場合はログを記録し、処理を中断すること', async () => {
+    it('パス生成に失敗した場合は処理を中断すること', async () => {
       const metadata: FlacMetadata = { title: 'T' };
       const mockTrack = new TrackRecord('old.flac', metadata);
       trackStore.tracks = [mockTrack];
       selectionState.selectSingle(mockTrack, 0);
 
-      vi.mocked(formatter.formatFlacFilename).mockReturnValue(
-        failure({ type: 'PARSE_FAILED', options: { path: 'old.flac' } })
+      vi.mocked(pathAdapter.generateNewPath).mockResolvedValue(
+        failure(tagErrors.parseFailed({ path: 'old.flac' }))
       );
 
       await fileActions.renameSelectedFiles();
 
-      expect(logStore.latestLog?.level).toBe('ERROR');
       expect(fileRepository.renameFile).not.toHaveBeenCalled();
     });
 

--- a/src/renderer/src/services/file-actions.ts
+++ b/src/renderer/src/services/file-actions.ts
@@ -1,15 +1,12 @@
-import { formatFlacFilename } from '@domain/flac/filename-formatter';
+import { success, type Result } from '@domain/common/result';
+import type { TagError } from '@domain/flac/types';
+import { generateNewPath } from '@renderer/infrastructure/adapters/path-adapter';
+import { fileRepository } from '@renderer/infrastructure/repositories/file-repository';
+import { tagRepository } from '@renderer/infrastructure/repositories/tag-repository';
+import { selectionState } from '@renderer/stores/selection-state.svelte';
 import { TrackRecord } from '@renderer/stores/track-record.svelte';
 import { trackStore } from '@renderer/stores/track-store.svelte';
 import { uiState } from '@renderer/stores/ui-state.svelte';
-import { selectionState } from '@renderer/stores/selection-state.svelte';
-import { tagRepository } from '@renderer/infrastructure/repositories/tag-repository';
-import { fileRepository } from '@renderer/infrastructure/repositories/file-repository';
-import { getDirectoryName, joinPath } from '@renderer/infrastructure/adapters/path-adapter';
-import { logStore } from '@renderer/stores/log-store.svelte';
-import { formatTagError } from '@domain/flac/tag-error-formatter';
-import { success, type Result } from '@domain/common/result';
-import type { TagError } from '@domain/flac/types';
 
 /**
  * 選択中のファイルをメタデータに基づいてリネームします。
@@ -62,25 +59,20 @@ const executeRenameLoop = async (selected: TrackRecord[]): Promise<Map<string, T
  * 成功した場合は新しい TrackRecord を返し、スキップ（変更不要など）時は null を返します。
  */
 const renameTrack = async (track: TrackRecord): Promise<Result<TrackRecord | null, TagError>> => {
-  // 1. フォーマット処理（メタデータが足りない場合は Result 型のエラーが返る）
-  const filenameResult = formatFlacFilename(track.toFlacTrack());
-  if (filenameResult.type === 'error') {
-    // レンダラー側のエラーなので明示的にログ追加
-    logStore.addError(formatTagError(filenameResult.error));
-    return filenameResult;
+  // 1. メタデータに基づいた新しいパスの生成（フォーマットとパス結合を一括で行う）
+  const pathResult = await generateNewPath(track.toFlacTrack());
+  if (pathResult.type === 'error') {
+    return pathResult;
   }
 
-  // 2. 新しいパスの取得と重複チェック（既存のフォルダ構造を維持して置換）
-  const dir = await getDirectoryName(track.path);
-  const newPath = await joinPath(dir, filenameResult.value);
+  const newPath = pathResult.value;
   if (track.path === newPath) {
     return success(null);
   }
 
-  // 3. 物理的なリネーム実行
+  // 2. 物理的なリネーム実行
   const result = await fileRepository.renameFile(track.path, newPath);
   if (result.type === 'error') {
-    // メインプロセス側で既にログ出力されているため、ここでは Result を返すのみ
     return result;
   }
 

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -26,14 +26,12 @@ export const IPC_CHANNELS = {
   GET_IMAGE_INFO: 'tag:get-image-info',
   /** ファイルのリネーム */
   RENAME_FILE: 'tag:rename-file',
+  /** メタデータに基づいた新しいパスの生成 */
+  GENERATE_NEW_PATH: 'tag:generate-new-path',
   /** ログメッセージの通知 */
   ON_LOG_MESSAGE: 'app:on-log-message',
   /** 実行環境のプラットフォームを取得 */
-  GET_PLATFORM: 'app:get-platform',
-  /** ディレクトリ名を取得 */
-  PATH_DIRNAME: 'path:dirname',
-  /** パスを結合 */
-  PATH_JOIN: 'path:join'
+  GET_PLATFORM: 'app:get-platform'
 } as const;
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];
@@ -56,13 +54,10 @@ export interface IpcApi {
   getImageInfo: (filePath: string) => Promise<TagResult<Picture>>;
   /** ファイルをリネーム（移動）します */
   renameFile: (oldPath: string, newPath: string) => Promise<TagResult<void>>;
+  /** メタデータに基づいて新しいファイルパスを生成します */
+  generateNewPath: (track: FlacTrack) => Promise<TagResult<string>>;
   /** File オブジェクトから OS 上のファイルシステムパスを取得します */
   getPathForFile: (file: File) => string;
-  /** パス操作（メインプロセス経由） */
-  path: {
-    dirname: (path: string) => Promise<string>;
-    join: (...paths: string[]) => Promise<string>;
-  };
   /** 実行環境のプラットフォームを取得します */
   getPlatform: () => Promise<Platform>;
   /** ログメッセージを受信した時のコールバックを登録します */


### PR DESCRIPTION
Issue #117 に対応しました。

### 変更内容
- **パス生成の最適化**:
  - `renameTrack` 時に行っていた複数のパス操作（dirname, join）を、メインプロセス側の新しいIPCチャンネル `GENERATE_NEW_PATH` 1回に集約しました。
  - これによりリネーム時のIPC通信回数を削減し、パフォーマンスを向上させました。
- **アーキテクチャの整理**:
  - パス算出ロジックを `src/main/services/flac/renamer.ts` に集約し、レンダラー側から Node.js 依存を排除しました。
  - メインプロセス側で `withResultLogging` を使用し、実行結果のログ記録とレンダラー通知を自動化しました。
- **UI/UX改善**:
  - `StatusBar.svelte` に、セッション中初めてログが追加された際、自動でパネルを展開するロジックを実装しました。
- **クリーンアップ**:
  - 不要になった `PATH_DIRNAME`, `PATH_JOIN` チャンネルおよび関連するアダプター/ブリッジコードを削除しました。

### 検証内容
- `pnpm test`: 全ての単体テストがパスすることを確認済み。
- `pnpm lint`: 静的解析エラーがないことを確認済み。
- `pnpm build`: ビルドが正常に終了することを確認済み。