### PR TITLE
feat: インスペクターの入力同期タイミングの最適化 (#123)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/inspector/BasicFields.svelte
+++ b/src/renderer/src/components/inspector/BasicFields.svelte
@@ -6,7 +6,7 @@
   import {
     getSingleFieldValue,
     handleSingleFieldChange,
-    handleEnterKey,
+    handleEnterToBlur,
     getMultiFieldValues
   } from './tag-field-handlers';
 </script>
@@ -24,7 +24,7 @@
         type="text"
         value={getSingleFieldValue('title')}
         onblur={(e) => handleSingleFieldChange('title', e)}
-        onkeydown={handleEnterKey}
+        onkeydown={handleEnterToBlur}
         placeholder="Title"
         disabled={trackStore.selectedTracks.length > 1}
         class:disabled={trackStore.selectedTracks.length > 1}
@@ -48,7 +48,7 @@
         type="text"
         value={getSingleFieldValue('album')}
         onblur={(e) => handleSingleFieldChange('album', e)}
-        onkeydown={handleEnterKey}
+        onkeydown={handleEnterToBlur}
         placeholder="Album"
       />
     </div>
@@ -71,7 +71,7 @@
         type="text"
         value={getSingleFieldValue('catalogNumber')}
         onblur={(e) => handleSingleFieldChange('catalogNumber', e)}
-        onkeydown={handleEnterKey}
+        onkeydown={handleEnterToBlur}
         placeholder="Catalog Number (e.g. ABCD-1234)"
       />
     </div>

--- a/src/renderer/src/components/inspector/BasicFields.svelte
+++ b/src/renderer/src/components/inspector/BasicFields.svelte
@@ -5,7 +5,8 @@
   import MultiValueField from '@renderer/components/ui/MultiValueField.svelte';
   import {
     getSingleFieldValue,
-    handleSingleInput,
+    handleSingleFieldChange,
+    handleEnterKey,
     getMultiFieldValues
   } from './tag-field-handlers';
 </script>
@@ -22,7 +23,8 @@
         id="title"
         type="text"
         value={getSingleFieldValue('title')}
-        oninput={(e) => handleSingleInput('title', e)}
+        onblur={(e) => handleSingleFieldChange('title', e)}
+        onkeydown={handleEnterKey}
         placeholder="Title"
         disabled={trackStore.selectedTracks.length > 1}
         class:disabled={trackStore.selectedTracks.length > 1}
@@ -45,7 +47,8 @@
         id="album"
         type="text"
         value={getSingleFieldValue('album')}
-        oninput={(e) => handleSingleInput('album', e)}
+        onblur={(e) => handleSingleFieldChange('album', e)}
+        onkeydown={handleEnterKey}
         placeholder="Album"
       />
     </div>
@@ -67,7 +70,8 @@
         id="catalogNumber"
         type="text"
         value={getSingleFieldValue('catalogNumber')}
-        oninput={(e) => handleSingleInput('catalogNumber', e)}
+        onblur={(e) => handleSingleFieldChange('catalogNumber', e)}
+        onkeydown={handleEnterKey}
         placeholder="Catalog Number (e.g. ABCD-1234)"
       />
     </div>

--- a/src/renderer/src/components/inspector/NumericFields.svelte
+++ b/src/renderer/src/components/inspector/NumericFields.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { tagActions } from '@renderer/services/tag-actions';
   import { trackStore } from '@renderer/stores/track-store.svelte';
-  import { getSingleFieldValue, handleSingleInput } from './tag-field-handlers';
+  import {
+    getSingleFieldValue,
+    handleSingleFieldChange,
+    handleEnterKey
+  } from './tag-field-handlers';
 </script>
 
 {#if trackStore.commonMetadata}
@@ -24,7 +28,8 @@
           id="trackNumber"
           type="text"
           value={getSingleFieldValue('trackNumber')}
-          oninput={(e) => handleSingleInput('trackNumber', e)}
+          onblur={(e) => handleSingleFieldChange('trackNumber', e)}
+          onkeydown={handleEnterKey}
           placeholder="#"
           disabled={trackStore.selectedTracks.length > 1}
           class:disabled={trackStore.selectedTracks.length > 1}
@@ -34,7 +39,8 @@
           id="trackTotal"
           type="text"
           value={getSingleFieldValue('trackTotal')}
-          oninput={(e) => handleSingleInput('trackTotal', e)}
+          onblur={(e) => handleSingleFieldChange('trackTotal', e)}
+          onkeydown={handleEnterKey}
           placeholder="Tracks"
         />
       </div>
@@ -47,7 +53,8 @@
           id="discNumber"
           type="text"
           value={getSingleFieldValue('discNumber')}
-          oninput={(e) => handleSingleInput('discNumber', e)}
+          onblur={(e) => handleSingleFieldChange('discNumber', e)}
+          onkeydown={handleEnterKey}
           placeholder="#"
         />
         <span class="separator">/</span>
@@ -55,7 +62,8 @@
           id="discTotal"
           type="text"
           value={getSingleFieldValue('discTotal')}
-          oninput={(e) => handleSingleInput('discTotal', e)}
+          onblur={(e) => handleSingleFieldChange('discTotal', e)}
+          onkeydown={handleEnterKey}
           placeholder="Discs"
         />
       </div>
@@ -67,7 +75,8 @@
         id="date"
         type="text"
         value={getSingleFieldValue('date')}
-        oninput={(e) => handleSingleInput('date', e)}
+        onblur={(e) => handleSingleFieldChange('date', e)}
+        onkeydown={handleEnterKey}
         placeholder="YYYY"
       />
     </div>

--- a/src/renderer/src/components/inspector/NumericFields.svelte
+++ b/src/renderer/src/components/inspector/NumericFields.svelte
@@ -4,7 +4,7 @@
   import {
     getSingleFieldValue,
     handleSingleFieldChange,
-    handleEnterKey
+    handleEnterToBlur
   } from './tag-field-handlers';
 </script>
 
@@ -29,7 +29,7 @@
           type="text"
           value={getSingleFieldValue('trackNumber')}
           onblur={(e) => handleSingleFieldChange('trackNumber', e)}
-          onkeydown={handleEnterKey}
+          onkeydown={handleEnterToBlur}
           placeholder="#"
           disabled={trackStore.selectedTracks.length > 1}
           class:disabled={trackStore.selectedTracks.length > 1}
@@ -40,7 +40,7 @@
           type="text"
           value={getSingleFieldValue('trackTotal')}
           onblur={(e) => handleSingleFieldChange('trackTotal', e)}
-          onkeydown={handleEnterKey}
+          onkeydown={handleEnterToBlur}
           placeholder="Tracks"
         />
       </div>
@@ -54,7 +54,7 @@
           type="text"
           value={getSingleFieldValue('discNumber')}
           onblur={(e) => handleSingleFieldChange('discNumber', e)}
-          onkeydown={handleEnterKey}
+          onkeydown={handleEnterToBlur}
           placeholder="#"
         />
         <span class="separator">/</span>
@@ -63,7 +63,7 @@
           type="text"
           value={getSingleFieldValue('discTotal')}
           onblur={(e) => handleSingleFieldChange('discTotal', e)}
-          onkeydown={handleEnterKey}
+          onkeydown={handleEnterToBlur}
           placeholder="Discs"
         />
       </div>
@@ -76,7 +76,7 @@
         type="text"
         value={getSingleFieldValue('date')}
         onblur={(e) => handleSingleFieldChange('date', e)}
-        onkeydown={handleEnterKey}
+        onkeydown={handleEnterToBlur}
         placeholder="YYYY"
       />
     </div>

--- a/src/renderer/src/components/inspector/tag-field-handlers.ts
+++ b/src/renderer/src/components/inspector/tag-field-handlers.ts
@@ -17,6 +17,7 @@ export const handleSingleFieldChange = (key: EditableSingleKey, e: Event): void 
 const enterHandler = new KeyboardHandler(IS_MAC, [
   {
     combo: { key: 'Enter' },
+    ignoreComposition: true,
     handler: (e) => (e.target as HTMLElement).blur()
   }
 ]);

--- a/src/renderer/src/components/inspector/tag-field-handlers.ts
+++ b/src/renderer/src/components/inspector/tag-field-handlers.ts
@@ -25,7 +25,7 @@ const enterHandler = new KeyboardHandler(IS_MAC, [
  * Enterキーが押された際、入力欄からフォーカスを外します。
  */
 export const handleEnterKey = (e: KeyboardEvent): void => {
-  void enterHandler.handle(e);
+  enterHandler.handle(e);
 };
 
 /**

--- a/src/renderer/src/components/inspector/tag-field-handlers.ts
+++ b/src/renderer/src/components/inspector/tag-field-handlers.ts
@@ -2,6 +2,9 @@ import type { EditableSingleKey, FieldState } from '@domain/editor/batch-metadat
 import { trackStore } from '@renderer/stores/track-store.svelte';
 import { tagActions } from '@renderer/services/tag-actions';
 
+import { IS_MAC } from '@renderer/constants/platform';
+import { KeyboardHandler } from '@renderer/utils/keyboard-handler';
+
 /**
  * 単一値フィールドの変更イベントを処理し、trackStore を更新します。
  * 通常、blur または Enter キー押下時に呼び出されます。
@@ -11,14 +14,18 @@ export const handleSingleFieldChange = (key: EditableSingleKey, e: Event): void 
   tagActions.updateSelectedSingleField(key, input.value);
 };
 
+const enterHandler = new KeyboardHandler(IS_MAC, [
+  {
+    combo: { key: 'Enter' },
+    handler: (e) => (e.target as HTMLElement).blur()
+  }
+]);
+
 /**
  * Enterキーが押された際、入力欄からフォーカスを外します。
- * これにより blur イベントが発火し、変更が確定されます。
  */
 export const handleEnterKey = (e: KeyboardEvent): void => {
-  if (e.key === 'Enter') {
-    (e.target as HTMLElement).blur();
-  }
+  void enterHandler.handle(e);
 };
 
 /**

--- a/src/renderer/src/components/inspector/tag-field-handlers.ts
+++ b/src/renderer/src/components/inspector/tag-field-handlers.ts
@@ -24,7 +24,7 @@ const enterHandler = new KeyboardHandler(IS_MAC, [
 /**
  * Enterキーが押された際、入力欄からフォーカスを外します。
  */
-export const handleEnterKey = (e: KeyboardEvent): void => {
+export const handleEnterToBlur = (e: KeyboardEvent): void => {
   enterHandler.handle(e);
 };
 

--- a/src/renderer/src/components/inspector/tag-field-handlers.ts
+++ b/src/renderer/src/components/inspector/tag-field-handlers.ts
@@ -3,11 +3,22 @@ import { trackStore } from '@renderer/stores/track-store.svelte';
 import { tagActions } from '@renderer/services/tag-actions';
 
 /**
- * 単一値フィールドの入力イベントを処理し、trackStore を更新します。
+ * 単一値フィールドの変更イベントを処理し、trackStore を更新します。
+ * 通常、blur または Enter キー押下時に呼び出されます。
  */
-export const handleSingleInput = (key: EditableSingleKey, e: Event): void => {
+export const handleSingleFieldChange = (key: EditableSingleKey, e: Event): void => {
   const input = e.target as HTMLInputElement;
   tagActions.updateSelectedSingleField(key, input.value);
+};
+
+/**
+ * Enterキーが押された際、入力欄からフォーカスを外します。
+ * これにより blur イベントが発火し、変更が確定されます。
+ */
+export const handleEnterKey = (e: KeyboardEvent): void => {
+  if (e.key === 'Enter') {
+    (e.target as HTMLElement).blur();
+  }
 };
 
 /**

--- a/src/renderer/src/components/ui/MultiValueField.svelte
+++ b/src/renderer/src/components/ui/MultiValueField.svelte
@@ -36,6 +36,12 @@
     const input = e.target as HTMLInputElement;
     onApplyChange?.(oldValue, input.value);
   };
+
+  const handleKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === 'Enter') {
+      (e.target as HTMLElement).blur();
+    }
+  };
 </script>
 
 <div class="multi-value-field field">
@@ -59,6 +65,7 @@
             type="text"
             {value}
             onchange={(e) => handleDivergentUpdate(value, e)}
+            onkeydown={handleKeyDown}
             placeholder="Value"
           />
           <button
@@ -91,7 +98,8 @@
             type="text"
             {value}
             placeholder={i === 0 && children ? '' : placeholder}
-            oninput={(e) => handleUpdate(i, e)}
+            onblur={(e) => handleUpdate(i, e)}
+            onkeydown={handleKeyDown}
           />
           <button
             type="button"

--- a/src/renderer/src/components/ui/MultiValueField.svelte
+++ b/src/renderer/src/components/ui/MultiValueField.svelte
@@ -2,7 +2,7 @@
   import { Plus, X } from '@lucide/svelte';
   import type { Snippet } from 'svelte';
   import { UI_TOKENS } from '@renderer/constants/design-system';
-  import { handleEnterKey } from '@renderer/components/inspector/tag-field-handlers';
+  import { handleEnterToBlur } from '@renderer/components/inspector/tag-field-handlers';
 
   interface Props {
     label: string;
@@ -60,7 +60,7 @@
             type="text"
             {value}
             onchange={(e) => handleDivergentUpdate(value, e)}
-            onkeydown={handleEnterKey}
+            onkeydown={handleEnterToBlur}
             placeholder="Value"
           />
           <button
@@ -94,7 +94,7 @@
             {value}
             placeholder={i === 0 && children ? '' : placeholder}
             onblur={(e) => handleUpdate(i, e)}
-            onkeydown={handleEnterKey}
+            onkeydown={handleEnterToBlur}
           />
           <button
             type="button"

--- a/src/renderer/src/components/ui/MultiValueField.svelte
+++ b/src/renderer/src/components/ui/MultiValueField.svelte
@@ -2,6 +2,8 @@
   import { Plus, X } from '@lucide/svelte';
   import type { Snippet } from 'svelte';
   import { UI_TOKENS } from '@renderer/constants/design-system';
+  import { IS_MAC } from '@renderer/constants/platform';
+  import { KeyboardHandler } from '@renderer/utils/keyboard-handler';
 
   interface Props {
     label: string;
@@ -37,11 +39,12 @@
     onApplyChange?.(oldValue, input.value);
   };
 
-  const handleKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === 'Enter') {
-      (e.target as HTMLElement).blur();
+  const enterHandler = new KeyboardHandler(IS_MAC, [
+    {
+      combo: { key: 'Enter' },
+      handler: (e) => (e.target as HTMLElement).blur()
     }
-  };
+  ]);
 </script>
 
 <div class="multi-value-field field">
@@ -65,7 +68,7 @@
             type="text"
             {value}
             onchange={(e) => handleDivergentUpdate(value, e)}
-            onkeydown={handleKeyDown}
+            onkeydown={(e) => enterHandler.handle(e)}
             placeholder="Value"
           />
           <button
@@ -99,7 +102,7 @@
             {value}
             placeholder={i === 0 && children ? '' : placeholder}
             onblur={(e) => handleUpdate(i, e)}
-            onkeydown={handleKeyDown}
+            onkeydown={(e) => enterHandler.handle(e)}
           />
           <button
             type="button"

--- a/src/renderer/src/components/ui/MultiValueField.svelte
+++ b/src/renderer/src/components/ui/MultiValueField.svelte
@@ -2,8 +2,7 @@
   import { Plus, X } from '@lucide/svelte';
   import type { Snippet } from 'svelte';
   import { UI_TOKENS } from '@renderer/constants/design-system';
-  import { IS_MAC } from '@renderer/constants/platform';
-  import { KeyboardHandler } from '@renderer/utils/keyboard-handler';
+  import { handleEnterKey } from '@renderer/components/inspector/tag-field-handlers';
 
   interface Props {
     label: string;
@@ -38,13 +37,6 @@
     const input = e.target as HTMLInputElement;
     onApplyChange?.(oldValue, input.value);
   };
-
-  const enterHandler = new KeyboardHandler(IS_MAC, [
-    {
-      combo: { key: 'Enter' },
-      handler: (e) => (e.target as HTMLElement).blur()
-    }
-  ]);
 </script>
 
 <div class="multi-value-field field">
@@ -68,7 +60,7 @@
             type="text"
             {value}
             onchange={(e) => handleDivergentUpdate(value, e)}
-            onkeydown={(e) => enterHandler.handle(e)}
+            onkeydown={handleEnterKey}
             placeholder="Value"
           />
           <button
@@ -102,7 +94,7 @@
             {value}
             placeholder={i === 0 && children ? '' : placeholder}
             onblur={(e) => handleUpdate(i, e)}
-            onkeydown={(e) => enterHandler.handle(e)}
+            onkeydown={handleEnterKey}
           />
           <button
             type="button"

--- a/src/renderer/src/utils/keyboard-handler.ts
+++ b/src/renderer/src/utils/keyboard-handler.ts
@@ -29,6 +29,8 @@ export interface KeyboardAction {
    * false を返すと、キーが一致していてもアクションは実行されません。
    */
   enabled?: (e: KeyboardEvent) => boolean;
+  /** trueの場合、IME入力中（isComposing: true）のイベントを無視します。 */
+  ignoreComposition?: boolean;
 }
 
 /**
@@ -49,13 +51,13 @@ export class KeyboardHandler {
    * キーボードイベントを処理します。
    */
   async handle(e: KeyboardEvent): Promise<void> {
-    // IME入力中（変換中）のイベントは無視する
-    if (e.isComposing) {
+    const action = this.actions.find((a) => this.matches(e, a.combo));
+    if (!action) {
       return;
     }
 
-    const action = this.actions.find((a) => this.matches(e, a.combo));
-    if (!action) {
+    // IME入力中かつ無視オプションが有効な場合はスキップ
+    if (action.ignoreComposition && e.isComposing) {
       return;
     }
 

--- a/src/renderer/src/utils/keyboard-handler.ts
+++ b/src/renderer/src/utils/keyboard-handler.ts
@@ -49,6 +49,11 @@ export class KeyboardHandler {
    * キーボードイベントを処理します。
    */
   async handle(e: KeyboardEvent): Promise<void> {
+    // IME入力中（変換中）のイベントは無視する
+    if (e.isComposing) {
+      return;
+    }
+
     const action = this.actions.find((a) => this.matches(e, a.combo));
     if (!action) {
       return;


### PR DESCRIPTION
## 概要
インスペクター（サイドバーのタグ編集UI）の各テキスト入力欄において、入力の同期タイミングを `oninput`（毎回のキー入力）から `onblur`（フォーカスが外れた時）および Enter キー押下時に変更しました。

## 変更内容
* `src/renderer/src/components/inspector/tag-field-handlers.ts`:
    * `handleSingleInput` を `handleSingleFieldChange` に改名
    * Enterキー押下時にフォーカスを外す共通ハンドラ `handleEnterKey` を追加
* `BasicFields.svelte` / `NumericFields.svelte`:
    * `oninput` を `onblur` に置き換え
    * `onkeydown={handleEnterKey}` を追加
* `MultiValueField.svelte`:
    * `oninput` を `onblur` に置き換え
    * Enterキーでフォーカスを外す処理を追加

## 検証内容
* `pnpm lint`: PASS
* `pnpm build`: PASS
* `pnpm test`: PASS
* 大量（500件）のファイルを選択している場合でも、入力中のUIのラグが発生しないことを想定した構造に変更されました。

Closes #123