### PR TITLE
release: v1.0.0 🎉 (fix: ログ表示の改善とアイコン刷新 #135)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.15.3",
+  "version": "1.0.0",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.15.7",
+  "version": "0.15.3",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -81,7 +81,7 @@
         <div class="status-item ready">
           <span>Ready</span>
         </div>
-      {/if}
+      /if}
     </div>
 
     <div class="expand-icon" class:is-expanded={isExpanded}>
@@ -94,7 +94,7 @@
       <div class="log-list" bind:this={logListElement}>
         {#each logStore.logs as log (log.id)}
           {@const ICON = levelIcons.get(log.level)}
-          <div class="log-entry {log.level}">
+          <div class="log-entry {log.level.toLowerCase()}">
             <span class="timestamp">[{formatTimeWithMs(log.timestamp)}]</span>
             <div class="log-level-icon">
               <ICON size={UI_TOKENS.icons.sizeSmall} />

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -81,7 +81,7 @@
         <div class="status-item ready">
           <span>Ready</span>
         </div>
-      /if}
+      {/if}
     </div>
 
     <div class="expand-icon" class:is-expanded={isExpanded}>

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -239,6 +239,14 @@
     background-color: var(--bg-hover);
   }
 
+  .log-entry.warn:hover {
+    background-color: var(--accent-warning-hover);
+  }
+
+  .log-entry.error:hover {
+    background-color: var(--accent-error-hover);
+  }
+
   .log-time {
     color: var(--text-dim);
     flex-shrink: 0;

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -1,12 +1,6 @@
 <script lang="ts">
   import type { LogLevel } from '@domain/common/log';
-  import {
-    ChevronUp,
-    OctagonAlert,
-    CircleCheck,
-    TriangleAlert,
-    type LucideProps
-  } from '@lucide/svelte';
+  import { ChevronUp, X, Check, TriangleAlert, type LucideProps } from '@lucide/svelte';
   import { tooltip } from '@renderer/actions/tooltip';
   import { UI_TOKENS } from '@renderer/constants/design-system';
   import { IS_MAC } from '@renderer/constants/platform';
@@ -17,9 +11,9 @@
   import { slide } from 'svelte/transition';
 
   const levelIcons: ReadonlyMap<LogLevel, Component<LucideProps>> = new Map([
-    ['INFO', CircleCheck],
+    ['INFO', Check],
     ['WARN', TriangleAlert],
-    ['ERROR', OctagonAlert]
+    ['ERROR', X]
   ] as const);
 
   let isExpanded = $state(false);

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -159,12 +159,10 @@
 
   .status-item.error {
     color: var(--accent-error);
-    font-weight: 600;
   }
 
   .status-item.warn {
     color: var(--accent-warning);
-    font-weight: 500;
   }
 
   .status-item.ready {

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -167,16 +167,14 @@
     font-weight: 500;
   }
 
-  .status-item.info {
-    color: var(--accent-info);
-  }
-
   .status-item.ready {
     color: var(--text-muted);
   }
 
   .status-item.error .log-message,
-  .status-item.warn .log-message {
+  .status-item.warn .log-message,
+  .status-item.error .log-context,
+  .status-item.warn .log-context {
     color: inherit;
   }
 
@@ -256,28 +254,25 @@
     flex-shrink: 0;
   }
 
-  .log-entry.info .log-level-icon {
-    color: var(--accent-info);
-  }
-
   .log-entry.warn {
     background-color: var(--accent-warning-dim);
-  }
-  .log-entry.warn .log-level-icon {
-    color: var(--accent-warning);
-  }
-  .log-entry.warn .log-text {
     color: var(--accent-warning);
   }
 
   .log-entry.error {
     background-color: var(--accent-error-dim);
-  }
-  .log-entry.error .log-level-icon {
     color: var(--accent-error);
   }
+
+  .log-entry.warn .timestamp,
+  .log-entry.warn .log-context,
+  .log-entry.warn .log-level-icon,
+  .log-entry.warn .log-text,
+  .log-entry.error .timestamp,
+  .log-entry.error .log-context,
+  .log-entry.error .log-level-icon,
   .log-entry.error .log-text {
-    color: var(--accent-error);
+    color: inherit;
   }
 
   .log-text {

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -167,8 +167,17 @@
     font-weight: 500;
   }
 
+  .status-item.info {
+    color: var(--accent-info);
+  }
+
   .status-item.ready {
     color: var(--text-muted);
+  }
+
+  .status-item.error .log-message,
+  .status-item.warn .log-message {
+    color: inherit;
   }
 
   .log-message {
@@ -220,13 +229,14 @@
   .log-entry {
     display: flex;
     gap: 0.75rem;
-    align-items: baseline;
+    align-items: center;
     font-size: 0.7rem;
     line-height: 1.5;
-    padding: 0.1rem 0.4rem;
+    padding: 0.15rem 0.4rem;
     border-radius: 2px;
     width: fit-content;
     min-width: 100%;
+    transition: background-color 0.2s ease;
   }
 
   .log-entry:hover {
@@ -247,12 +257,26 @@
   }
 
   .log-entry.info .log-level-icon {
-    color: #4da6ff;
+    color: var(--accent-info);
+  }
+
+  .log-entry.warn {
+    background-color: var(--accent-warning-dim);
   }
   .log-entry.warn .log-level-icon {
     color: var(--accent-warning);
   }
+  .log-entry.warn .log-text {
+    color: var(--accent-warning);
+  }
+
+  .log-entry.error {
+    background-color: var(--accent-error-dim);
+  }
   .log-entry.error .log-level-icon {
+    color: var(--accent-error);
+  }
+  .log-entry.error .log-text {
     color: var(--accent-error);
   }
 

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import type { LogLevel } from '@domain/common/log';
-  import { ChevronUp, CircleAlert, Info, TriangleAlert, type LucideProps } from '@lucide/svelte';
+  import {
+    ChevronUp,
+    OctagonAlert,
+    CircleCheck,
+    TriangleAlert,
+    type LucideProps
+  } from '@lucide/svelte';
   import { tooltip } from '@renderer/actions/tooltip';
   import { UI_TOKENS } from '@renderer/constants/design-system';
   import { IS_MAC } from '@renderer/constants/platform';
@@ -11,9 +17,9 @@
   import { slide } from 'svelte/transition';
 
   const levelIcons: ReadonlyMap<LogLevel, Component<LucideProps>> = new Map([
-    ['INFO', Info],
+    ['INFO', CircleCheck],
     ['WARN', TriangleAlert],
-    ['ERROR', CircleAlert]
+    ['ERROR', OctagonAlert]
   ] as const);
 
   let isExpanded = $state(false);

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -23,6 +23,7 @@
   --accent-modified: #ff9500;
   --accent-error: #ff3b30;
   --accent-warning: #ff9f0a;
+  --accent-info: #4de800; /* 緑系のINFOカラー */
 
   /* 透過済みカラーのプリセット (HEX Alpha) */
   --bg-overlay: #1e1e1ee6;
@@ -31,6 +32,9 @@
   --selection-glow: #adff2fcc;
   --accent-modified-glow: #ff950066;
   --accent-primary-dim: #adff2f1a;
+  --accent-error-dim: #ff3b301a;
+  --accent-warning-dim: #ff9f0a1a;
+  --accent-info-dim: #4de8001a;
 
   /* 角丸 */
   --radius-sm: 4px;

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -35,6 +35,8 @@
   --accent-error-dim: #ff3b301a;
   --accent-warning-dim: #ff9f0a1a;
   --accent-info-dim: #4de8001a;
+  --accent-error-hover: #ff3b3033;
+  --accent-warning-hover: #ff9f0a33;
 
   /* 角丸 */
   --radius-sm: 4px;

--- a/src/renderer/src/stores/log-store.svelte.test.ts
+++ b/src/renderer/src/stores/log-store.svelte.test.ts
@@ -16,7 +16,13 @@ describe('LogStore', () => {
   });
 
   it('addLog でログを追加できること', () => {
-    const log = { id: '1', level: 'INFO' as const, message: 'Test message', timestamp: Date.now() };
+    const log = {
+      id: '1',
+      level: 'INFO' as const,
+      context: 'Test',
+      message: 'Test message',
+      timestamp: Date.now()
+    };
     logStore.addLog(log);
 
     expect(logStore.logs).toHaveLength(1);
@@ -25,13 +31,13 @@ describe('LogStore', () => {
   });
 
   it('addError でエラーログを追加できること', () => {
-    logStore.addError('Error message');
+    logStore.addError({ context: 'Test', message: 'Error message' });
     expect(logStore.latestLog?.level).toBe('ERROR');
     expect(logStore.latestLog?.message).toBe('Error message');
   });
 
   it('addWarn で警告ログを追加できること', () => {
-    logStore.addWarn('Warn message');
+    logStore.addWarn({ context: 'Test', message: 'Warn message' });
     expect(logStore.latestLog?.level).toBe('WARN');
     expect(logStore.latestLog?.message).toBe('Warn message');
   });
@@ -42,6 +48,7 @@ describe('LogStore', () => {
       logStore.addLog({
         id: `${i}`,
         level: 'INFO',
+        context: 'Test',
         message: `Message ${i}`,
         timestamp: Date.now()
       });


### PR DESCRIPTION
## 概要
GitHub Issue #135「ログのアイコン表示不正」への対応を完了し、UIの品質向上を記念して **v1.0.0** としてメジャーリリースします。

## 変更内容
1.  **レイアウト修正** (`StatusBar.svelte`):
    *   ログアイコンの垂直位置がテキストの中央に揃うように修正しました。
2.  **配色の改善** (`index.css`, `StatusBar.svelte`):
    *   WARN/ERROR ログに対し、行全体（タイムスタンプ、アイコン、コンテキスト、メッセージ）をアクセントカラーで強調表示するようにしました。
    - ホバー時に背景色が変化するインタラクションを追加し、操作フィードバックを強化しました。
    - メインバーのエラー表示は太字を解除し、色のみでスマートに強調するように調整しました。
3.  **アイコンの刷新** (Lucide Icons):
    - 視認性と判別性を高めるため、レベルごとに異なる形状のアイコンを採用しました。
    - **INFO**: `Check`（チェックマークのみ）
    - **WARN**: `TriangleAlert`（三角形に感嘆符）
    - **ERROR**: `X`（X印のみ）
4.  **品質管理**:
    *   `log-store.svelte.test.ts` の型エラーとロジックエラーを修正し、テストカバレッジを維持しました。
5.  **バージョン更新** (`package.json`):
    *   **v1.0.0** にメジャーバージョンアップしました。

## 検証内容
*   `pnpm lint`: PASS
*   `pnpm build`: PASS
*   `pnpm test`: PASS (全てのテストが正常に完了することを確認)
*   `pnpm format`: 実行済み

メジャーリリースにふさわしい、使いやすく視認性の高いログ機能になりました。
