### PR TITLE
feat: メインウィンドウに最小サイズ制限を追加 (#143)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -8,6 +8,8 @@ export const createWindow = (): BrowserWindow => {
   const mainWindow = new BrowserWindow({
     width: 1400,
     height: 1000,
+    minWidth: 960,
+    minHeight: 600,
     show: false,
     autoHideMenuBar: true,
     backgroundColor: '#1e1e1e',


### PR DESCRIPTION
## 概要
GitHub Issue #143 に対応し、メインウィンドウに最小サイズ（幅960px、高さ600px）を設定しました。

## 変更内容
- `src/main/window.ts` の `BrowserWindow` オプションに `minWidth: 960` および `minHeight: 600` を追加。
- `package.json` のバージョンを `1.1.1` に更新。

## 検証内容
- `pnpm format`: パス
- `pnpm lint`: パス
- `pnpm build`: パス
- `pnpm test`: パス

これにより、ウィンドウを極端に小さくした際のレイアウト崩れを防ぐことができます。
close #143