### PR TITLE
fix: インスペクターの入力同期を即時化しスキャン件数に制限を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/domain/common/messages.ts
+++ b/src/domain/common/messages.ts
@@ -3,7 +3,7 @@
  */
 export const MESSAGES = {
   /** スキャン件数制限に達した場合の警告メッセージ */
-  SCAN_LIMIT_EXCEEDED: 'Scan limit (500 items) reached. Some files were skipped.',
+  SCAN_LIMIT_EXCEEDED: 'Scan limit reached. Some files were skipped.',
 
   /** タグ操作に関連するエラーメッセージ */
   TAG_ERRORS: {

--- a/src/main/services/flac/scanner.ts
+++ b/src/main/services/flac/scanner.ts
@@ -11,7 +11,7 @@ import { determinePathType, resolvePaths } from './path-resolver';
  * スキャンするファイルの最大件数。
  * パフォーマンスとメモリの観点から制限を設けます。
  */
-const MAX_SCAN_FILES = 500;
+const MAX_SCAN_FILES = 300;
 
 /**
  * 探索処理の状態を管理するコンテキスト。

--- a/src/renderer/src/components/inspector/BasicFields.svelte
+++ b/src/renderer/src/components/inspector/BasicFields.svelte
@@ -23,7 +23,7 @@
         id="title"
         type="text"
         value={getSingleFieldValue('title')}
-        onblur={(e) => handleSingleFieldChange('title', e)}
+        oninput={(e) => handleSingleFieldChange('title', e)}
         onkeydown={handleEnterToBlur}
         placeholder="Title"
         disabled={trackStore.selectedTracks.length > 1}
@@ -47,7 +47,7 @@
         id="album"
         type="text"
         value={getSingleFieldValue('album')}
-        onblur={(e) => handleSingleFieldChange('album', e)}
+        oninput={(e) => handleSingleFieldChange('album', e)}
         onkeydown={handleEnterToBlur}
         placeholder="Album"
       />
@@ -70,7 +70,7 @@
         id="catalogNumber"
         type="text"
         value={getSingleFieldValue('catalogNumber')}
-        onblur={(e) => handleSingleFieldChange('catalogNumber', e)}
+        oninput={(e) => handleSingleFieldChange('catalogNumber', e)}
         onkeydown={handleEnterToBlur}
         placeholder="Catalog Number (e.g. ABCD-1234)"
       />

--- a/src/renderer/src/components/inspector/NumericFields.svelte
+++ b/src/renderer/src/components/inspector/NumericFields.svelte
@@ -28,7 +28,7 @@
           id="trackNumber"
           type="text"
           value={getSingleFieldValue('trackNumber')}
-          onblur={(e) => handleSingleFieldChange('trackNumber', e)}
+          oninput={(e) => handleSingleFieldChange('trackNumber', e)}
           onkeydown={handleEnterToBlur}
           placeholder="#"
           disabled={trackStore.selectedTracks.length > 1}
@@ -39,7 +39,7 @@
           id="trackTotal"
           type="text"
           value={getSingleFieldValue('trackTotal')}
-          onblur={(e) => handleSingleFieldChange('trackTotal', e)}
+          oninput={(e) => handleSingleFieldChange('trackTotal', e)}
           onkeydown={handleEnterToBlur}
           placeholder="Tracks"
         />
@@ -53,7 +53,7 @@
           id="discNumber"
           type="text"
           value={getSingleFieldValue('discNumber')}
-          onblur={(e) => handleSingleFieldChange('discNumber', e)}
+          oninput={(e) => handleSingleFieldChange('discNumber', e)}
           onkeydown={handleEnterToBlur}
           placeholder="#"
         />
@@ -62,7 +62,7 @@
           id="discTotal"
           type="text"
           value={getSingleFieldValue('discTotal')}
-          onblur={(e) => handleSingleFieldChange('discTotal', e)}
+          oninput={(e) => handleSingleFieldChange('discTotal', e)}
           onkeydown={handleEnterToBlur}
           placeholder="Discs"
         />
@@ -75,7 +75,7 @@
         id="date"
         type="text"
         value={getSingleFieldValue('date')}
-        onblur={(e) => handleSingleFieldChange('date', e)}
+        oninput={(e) => handleSingleFieldChange('date', e)}
         onkeydown={handleEnterToBlur}
         placeholder="YYYY"
       />

--- a/src/renderer/src/components/ui/MultiValueField.svelte
+++ b/src/renderer/src/components/ui/MultiValueField.svelte
@@ -59,7 +59,7 @@
           <input
             type="text"
             {value}
-            onchange={(e) => handleDivergentUpdate(value, e)}
+            oninput={(e) => handleDivergentUpdate(value, e)}
             onkeydown={handleEnterToBlur}
             placeholder="Value"
           />
@@ -93,7 +93,7 @@
             type="text"
             {value}
             placeholder={i === 0 && children ? '' : placeholder}
-            onblur={(e) => handleUpdate(i, e)}
+            oninput={(e) => handleUpdate(i, e)}
             onkeydown={handleEnterToBlur}
           />
           <button


### PR DESCRIPTION
## 概要
インスペクターの入力欄の同期タイミングを見直し、UXの向上とアーキテクチャの簡素化を行いました。

## 変更内容
- **入力同期の即時化**: インスペクター内の各入力フィールド（Title, Album, Track等）の同期タイミングを `onblur` から `oninput` に変更しました。これにより、フォーカスが外れていない状態でも `Ctrl+S` による保存が正しく機能するようになります。
- **スキャン件数の制限**: パフォーマンスを担保するため、一度にスキャン・読み込み可能なファイル件数を300件に制限しました。
- **メッセージの改善**: スキャン制限超過時の警告メッセージから具体的な数値を排し、メンテナンス性を向上させました。
- **バージョン更新**: `package.json` のバージョンを 1.1.3 に更新しました。

## 検証内容
- `pnpm format`, `pnpm lint`, `pnpm typecheck` がパスすることを確認済み
- `pnpm test` (Vitest) による全テストのパスを確認済み
- 300件のハードリミットが `src/main/services/flac/scanner.ts` に正しく設定されていることを確認
- インスペクターの各コンポーネントで `oninput` への移行が完了していることを確認
