### PR TITLE
refactor: rename TagResult to AppResult and TagError to AppError (#140)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/domain/common/messages.ts
+++ b/src/domain/common/messages.ts
@@ -5,8 +5,8 @@ export const MESSAGES = {
   /** スキャン件数制限に達した場合の警告メッセージ */
   SCAN_LIMIT_EXCEEDED: 'Scan limit reached. Some files were skipped.',
 
-  /** タグ操作に関連するエラーメッセージ */
-  TAG_ERRORS: {
+  /** アプリケーションにおけるエラーメッセージ */
+  APP_ERRORS: {
     FILE_NOT_FOUND: 'File not found',
     PERMISSION_DENIED: 'Permission denied',
     PARSE_FAILED: 'Failed to parse metadata',

--- a/src/domain/flac/app-error-formatter.test.ts
+++ b/src/domain/flac/app-error-formatter.test.ts
@@ -1,33 +1,33 @@
 import { describe, it, expect } from 'vitest';
-import { formatTagError } from './tag-error-formatter';
-import type { TagError } from './errors';
+import { formatAppError } from './app-error-formatter';
+import type { AppError } from './errors';
 
 describe('エラーフォーマッター', () => {
-  describe('formatTagError', () => {
-    it('TagError オブジェクトを適切に翻訳すること', () => {
-      const error: TagError = {
+  describe('formatAppError', () => {
+    it('AppError オブジェクトを適切に翻訳すること', () => {
+      const error: AppError = {
         type: 'FILE_NOT_FOUND',
         options: { path: 'test.flac' }
       };
-      expect(formatTagError(error)).toBe('File not found');
+      expect(formatAppError(error)).toBe('File not found');
     });
 
-    it('TagError に詳細情報がある場合、それを含めること', () => {
-      const error: TagError = {
+    it('AppError に詳細情報がある場合、それを含めること', () => {
+      const error: AppError = {
         type: 'WRITE_FAILED',
         options: { path: 'test.flac', detail: 'Disk full' }
       };
-      expect(formatTagError(error)).toBe('Failed to write metadata: Disk full');
+      expect(formatAppError(error)).toBe('Failed to write metadata: Disk full');
     });
 
     it('標準の Error オブジェクトからメッセージを取得すること', () => {
       const error = new Error('Generic error');
-      expect(formatTagError(error)).toBe('Generic error');
+      expect(formatAppError(error)).toBe('Generic error');
     });
 
     it('文字列やその他の値をそのまま文字列化すること', () => {
-      expect(formatTagError('Something bad')).toBe('Something bad');
-      expect(formatTagError(404)).toBe('404');
+      expect(formatAppError('Something bad')).toBe('Something bad');
+      expect(formatAppError(404)).toBe('404');
     });
 
     it('未知のエラータイプの場合、フォールバックメッセージを表示すること', () => {
@@ -36,7 +36,7 @@ describe('エラーフォーマッター', () => {
         options: { path: 'test.flac' }
       };
       // 型定義上はあり得ないが、実行時の安全性のためのテスト
-      expect(formatTagError(unknownError)).toBe('Unknown error');
+      expect(formatAppError(unknownError)).toBe('Unknown error');
     });
   });
 });

--- a/src/domain/flac/app-error-formatter.ts
+++ b/src/domain/flac/app-error-formatter.ts
@@ -1,11 +1,11 @@
-import { isTagError, type TagError } from './errors';
+import { isAppError, type AppError } from './errors';
 import { MESSAGES } from '@domain/common/messages';
 
 /**
- * TagError 型を人間が読めるメッセージに変換します。
+ * AppError 型を人間が読めるメッセージに変換します。
  */
-const translateTagError = (error: TagError): string => {
-  const label = MESSAGES.TAG_ERRORS[error.type] || 'Unknown error';
+const translateAppError = (error: AppError): string => {
+  const label = MESSAGES.APP_ERRORS[error.type] || 'Unknown error';
   const detail = error.options.detail;
 
   return detail ? `${label}: ${detail}` : label;
@@ -15,9 +15,9 @@ const translateTagError = (error: TagError): string => {
  * エラーオブジェクトを人間が読めるメッセージに変換します。
  * メインプロセスのロギングやレンダラープロセスのUI表示の両方で利用されます。
  */
-export const formatTagError = (error: unknown): string => {
-  if (isTagError(error)) {
-    return translateTagError(error);
+export const formatAppError = (error: unknown): string => {
+  if (isAppError(error)) {
+    return translateAppError(error);
   } else if (error instanceof Error) {
     return error.message;
   } else {

--- a/src/domain/flac/constants.ts
+++ b/src/domain/flac/constants.ts
@@ -1,7 +1,7 @@
 /**
- * タグ操作におけるエラー種別のリテラル一覧。
+ * アプリケーションにおけるエラー種別のリテラル一覧。
  */
-export const TAG_ERROR_TYPES = [
+export const APP_ERROR_TYPES = [
   'FILE_NOT_FOUND',
   'PERMISSION_DENIED',
   'PARSE_FAILED',

--- a/src/domain/flac/errors.ts
+++ b/src/domain/flac/errors.ts
@@ -1,15 +1,15 @@
-import { TAG_ERROR_TYPES } from './constants';
+import { APP_ERROR_TYPES } from './constants';
 
 /**
- * タグ操作におけるエラー種別のリテラル型。
+ * アプリケーションにおけるエラー種別のリテラル型。
  * 判別共用体 (Discriminated Union) の識別に利用します。
  */
-export type TagErrorType = (typeof TAG_ERROR_TYPES)[number];
+export type AppErrorType = (typeof APP_ERROR_TYPES)[number];
 
 /**
- * タグ操作におけるエラーの付随情報（メタデータ）。
+ * アプリケーションにおけるエラーの付随情報（メタデータ）。
  */
-export interface TagErrorOptions {
+export interface AppErrorOptions {
   /** 対象となったファイルやディレクトリのパス */
   path: string;
   /** 追加の詳細メッセージ（例: OSのエラーメッセージ、ライブラリの例外内容） */
@@ -17,33 +17,33 @@ export interface TagErrorOptions {
 }
 
 /**
- * タグ操作における詳細なエラー定義（判別共用体）。
+ * アプリケーションにおける詳細なエラー定義（判別共用体）。
  */
-export type TagError =
-  | { type: 'FILE_NOT_FOUND'; options: TagErrorOptions }
-  | { type: 'PERMISSION_DENIED'; options: TagErrorOptions }
-  | { type: 'PARSE_FAILED'; options: TagErrorOptions }
-  | { type: 'WRITE_FAILED'; options: TagErrorOptions }
-  | { type: 'SCAN_FAILED'; options: TagErrorOptions }
-  | { type: 'PICK_IMAGE_FAILED'; options: TagErrorOptions }
-  | { type: 'MISSING_REQUIRED_TAG'; options: TagErrorOptions }
-  | { type: 'INVALID_RENAME_PATTERN'; options: TagErrorOptions };
+export type AppError =
+  | { type: 'FILE_NOT_FOUND'; options: AppErrorOptions }
+  | { type: 'PERMISSION_DENIED'; options: AppErrorOptions }
+  | { type: 'PARSE_FAILED'; options: AppErrorOptions }
+  | { type: 'WRITE_FAILED'; options: AppErrorOptions }
+  | { type: 'SCAN_FAILED'; options: AppErrorOptions }
+  | { type: 'PICK_IMAGE_FAILED'; options: AppErrorOptions }
+  | { type: 'MISSING_REQUIRED_TAG'; options: AppErrorOptions }
+  | { type: 'INVALID_RENAME_PATTERN'; options: AppErrorOptions };
 
 /**
- * TagError を生成する共通のファクトリ関数。
+ * AppError を生成する共通のファクトリ関数。
  */
 const createFactory =
-  (type: TagErrorType) =>
-  (options: TagErrorOptions): TagError =>
+  (type: AppErrorType) =>
+  (options: AppErrorOptions): AppError =>
     ({
       type,
       options
-    }) as TagError;
+    }) as AppError;
 
 /**
- * TagError かどうかの型ガード
+ * AppError かどうかの型ガード
  */
-export const isTagError = (error: unknown): error is TagError => {
+export const isAppError = (error: unknown): error is AppError => {
   return (
     !!error &&
     typeof error === 'object' &&
@@ -56,7 +56,7 @@ export const isTagError = (error: unknown): error is TagError => {
 /**
  * 型安全にエラーオブジェクトを生成するためのファクトリ。
  */
-export const tagErrors = {
+export const appErrors = {
   fileNotFound: createFactory('FILE_NOT_FOUND'),
   permissionDenied: createFactory('PERMISSION_DENIED'),
   parseFailed: createFactory('PARSE_FAILED'),

--- a/src/domain/flac/filename-formatter.ts
+++ b/src/domain/flac/filename-formatter.ts
@@ -2,8 +2,8 @@ import { failure, success } from '@domain/common/result';
 import { ValuesOf } from '@shared/types';
 import { sanitize } from '@shared/utils/filename';
 import { TAG_PLACEHOLDERS } from './constants';
-import { tagErrors } from './errors';
-import type { TagResult } from './types';
+import { appErrors } from './errors';
+import type { AppResult } from './types';
 import type { FlacMetadata, FlacTrack } from './models';
 
 type ResolverOptions = { trackNumberPadding: number };
@@ -39,13 +39,13 @@ const PLACEHOLDER_RESOLVERS: Record<
  * @param track トラック情報
  * @param options 生成オプション
  */
-export const formatFlacFilename = (track: FlacTrack, options: FormatOptions): TagResult<string> => {
+export const formatFlacFilename = (track: FlacTrack, options: FormatOptions): AppResult<string> => {
   const placeholders = Object.values(TAG_PLACEHOLDERS) as ValuesOf<typeof TAG_PLACEHOLDERS>[];
 
   // パターンに少なくとも1つのプレースホルダが含まれているかチェック
   const hasPlaceholder = placeholders.some((placeholder) => options.pattern.includes(placeholder));
   if (!hasPlaceholder) {
-    return failure(tagErrors.invalidRenamePattern({ path: track.path }));
+    return failure(appErrors.invalidRenamePattern({ path: track.path }));
   }
 
   // 置換処理とバリデーション
@@ -60,7 +60,7 @@ export const formatFlacFilename = (track: FlacTrack, options: FormatOptions): Ta
 
     // 値が空（または未定義）の場合はエラー
     if (!value || value.toString().trim() === '') {
-      return failure(tagErrors.missingRequiredTag({ path: track.path, detail: placeholder }));
+      return failure(appErrors.missingRequiredTag({ path: track.path, detail: placeholder }));
     }
 
     filename = filename.replaceAll(placeholder, value.toString());

--- a/src/domain/flac/types.test.ts
+++ b/src/domain/flac/types.test.ts
@@ -1,54 +1,54 @@
 import { describe, it, expect } from 'vitest';
-import { tagErrors } from './errors';
-import { TAG_ERROR_TYPES } from './constants';
+import { appErrors } from './errors';
+import { APP_ERROR_TYPES } from './constants';
 
 describe('flac types', () => {
   const options = { path: '/test.flac', detail: 'error' };
 
-  describe('tagErrors', () => {
-    it('fileNotFound が正しい TagError を生成すること', () => {
-      const error = tagErrors.fileNotFound(options);
+  describe('appErrors', () => {
+    it('fileNotFound が正しい AppError を生成すること', () => {
+      const error = appErrors.fileNotFound(options);
       expect(error.type).toBe('FILE_NOT_FOUND');
       expect(error.options).toEqual(options);
     });
 
-    it('permissionDenied が正しい TagError を生成すること', () => {
-      const error = tagErrors.permissionDenied(options);
+    it('permissionDenied が正しい AppError を生成すること', () => {
+      const error = appErrors.permissionDenied(options);
       expect(error.type).toBe('PERMISSION_DENIED');
       expect(error.options).toEqual(options);
     });
 
-    it('parseFailed が正しい TagError を生成すること', () => {
-      const error = tagErrors.parseFailed(options);
+    it('parseFailed が正しい AppError を生成すること', () => {
+      const error = appErrors.parseFailed(options);
       expect(error.type).toBe('PARSE_FAILED');
       expect(error.options).toEqual(options);
     });
 
-    it('writeFailed が正しい TagError を生成すること', () => {
-      const error = tagErrors.writeFailed(options);
+    it('writeFailed が正しい AppError を生成すること', () => {
+      const error = appErrors.writeFailed(options);
       expect(error.type).toBe('WRITE_FAILED');
       expect(error.options).toEqual(options);
     });
 
-    it('scanFailed が正しい TagError を生成すること', () => {
-      const error = tagErrors.scanFailed(options);
+    it('scanFailed が正しい AppError を生成すること', () => {
+      const error = appErrors.scanFailed(options);
       expect(error.type).toBe('SCAN_FAILED');
       expect(error.options).toEqual(options);
     });
 
-    it('pickImageFailed が正しい TagError を生成すること', () => {
-      const error = tagErrors.pickImageFailed(options);
+    it('pickImageFailed が正しい AppError を生成すること', () => {
+      const error = appErrors.pickImageFailed(options);
       expect(error.type).toBe('PICK_IMAGE_FAILED');
       expect(error.options).toEqual(options);
     });
 
-    it('全ての TAG_ERROR_TYPES が網羅されていること (型レベルの確認を補完)', () => {
-      TAG_ERROR_TYPES.forEach((type) => {
+    it('全ての APP_ERROR_TYPES が網羅されていること (型レベルの確認を補完)', () => {
+      APP_ERROR_TYPES.forEach((type) => {
         // type が "FILE_NOT_FOUND" 形式なので、キャメルケースに変換してチェック
         const camelCaseType = type.toLowerCase().replace(/_([a-z])/g, (_, g) => g.toUpperCase());
         const key = camelCaseType.charAt(0).toLowerCase() + camelCaseType.slice(1);
 
-        expect(tagErrors).toHaveProperty(key);
+        expect(appErrors).toHaveProperty(key);
       });
     });
   });

--- a/src/domain/flac/types.ts
+++ b/src/domain/flac/types.ts
@@ -1,5 +1,5 @@
 import type { Result } from '@domain/common/result';
-import type { TagError } from './errors';
+import type { AppError } from './errors';
 
 /**
  * ディレクトリのスキャン結果を表すインターフェース。
@@ -12,7 +12,7 @@ export interface ScanResult {
 }
 
 /**
- * タグ取得・更新操作の戻り値型。
+ * アプリケーションの各操作の戻り値型。
  * Result型を利用した、例外を投げないエラーハンドリングを強制します。
  */
-export type TagResult<T> = Result<T, TagError>;
+export type AppResult<T> = Result<T, AppError>;

--- a/src/main/infrastructure/logging/result-logging.test.ts
+++ b/src/main/infrastructure/logging/result-logging.test.ts
@@ -1,6 +1,6 @@
 import { failure, success } from '@domain/common/result';
 import { logger } from '@services/platform/logger';
-import * as formatter from '@domain/flac/tag-error-formatter';
+import * as formatter from '@domain/flac/app-error-formatter';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { withResultLogging } from './result-logging';
 
@@ -11,7 +11,7 @@ describe('result-logging', () => {
     vi.spyOn(logger, 'info').mockImplementation(() => {});
     vi.spyOn(logger, 'error').mockImplementation(() => {});
     // formatter をスパイ（パスが間違っていれば import 時点でエラーになる）
-    vi.spyOn(formatter, 'formatTagError').mockImplementation((err) =>
+    vi.spyOn(formatter, 'formatAppError').mockImplementation((err) =>
       err instanceof Error ? err.message : String(err)
     );
   });
@@ -51,7 +51,7 @@ describe('result-logging', () => {
       const error = { type: 'PARSE_FAILED', options: { path: 'file.flac' } };
       const task = vi.fn().mockResolvedValue(failure(error));
       vi.spyOn(logger, 'warn').mockImplementation(() => {});
-      vi.mocked(formatter.formatTagError).mockReturnValue('Formatted Error Message');
+      vi.mocked(formatter.formatAppError).mockReturnValue('Formatted Error Message');
 
       const result = await withResultLogging('test-ctx', task);
 
@@ -60,13 +60,13 @@ describe('result-logging', () => {
         context: 'test-ctx',
         message: 'Formatted Error Message'
       });
-      expect(formatter.formatTagError).toHaveBeenCalledWith(error);
+      expect(formatter.formatAppError).toHaveBeenCalledWith(error);
     });
 
     it('例外が発生した場合、例外ログを出力して再スローすること', async () => {
       const error = new Error('Unexpected crash');
       const task = vi.fn().mockRejectedValue(error);
-      vi.mocked(formatter.formatTagError).mockReturnValue('Formatted Exception Message');
+      vi.mocked(formatter.formatAppError).mockReturnValue('Formatted Exception Message');
 
       await expect(withResultLogging('test-ctx', task)).rejects.toThrow('Unexpected crash');
 
@@ -74,7 +74,7 @@ describe('result-logging', () => {
         context: 'test-ctx',
         message: 'Formatted Exception Message'
       });
-      expect(formatter.formatTagError).toHaveBeenCalledWith(error);
+      expect(formatter.formatAppError).toHaveBeenCalledWith(error);
     });
   });
 });

--- a/src/main/infrastructure/logging/result-logging.ts
+++ b/src/main/infrastructure/logging/result-logging.ts
@@ -1,17 +1,17 @@
-import { formatTagError } from '@domain/flac/tag-error-formatter';
-import { type TagResult } from '@domain/flac/types';
+import { formatAppError } from '@domain/flac/app-error-formatter';
+import { type AppResult } from '@domain/flac/types';
 import { logger } from '@services/platform/logger';
 
 /**
  * 処理の実行結果（成功/失敗/例外）に基づいたロギングを行うラッパー関数。
- * TagResult を返す任意の非同期処理をラップし、結果に応じたログを出力します。
+ * AppResult を返す任意の非同期処理をラップし、結果に応じたログを出力します。
  *
  * @param context 処理の識別子（ログに出力される識別名）
  * @param task 実行する非同期処理
  * @param message 補足メッセージ（任意。パスやパラメータなど）
  * @returns 処理結果
  */
-export const withResultLogging = async <R extends TagResult<unknown>>(
+export const withResultLogging = async <R extends AppResult<unknown>>(
   context: string,
   task: () => Promise<R>,
   ...params: unknown[]
@@ -20,7 +20,7 @@ export const withResultLogging = async <R extends TagResult<unknown>>(
   try {
     result = await task();
   } catch (error: unknown) {
-    logger.error({ context, message: formatTagError(error) }, ...params);
+    logger.error({ context, message: formatAppError(error) }, ...params);
     throw error;
   }
 
@@ -29,7 +29,7 @@ export const withResultLogging = async <R extends TagResult<unknown>>(
     return result;
   }
 
-  logger.warn({ context, message: formatTagError(result.error) }, ...params);
+  logger.warn({ context, message: formatAppError(result.error) }, ...params);
 
   return result;
 };

--- a/src/main/services/flac/image.ts
+++ b/src/main/services/flac/image.ts
@@ -1,5 +1,5 @@
 import { success } from '@domain/common/result';
-import { TagResult } from '@domain/flac/types';
+import { AppResult } from '@domain/flac/types';
 import { Picture } from '@domain/flac/models';
 import { readFile } from 'node:fs/promises';
 import { computeMd5 } from '@main/utils/crypto';
@@ -30,7 +30,7 @@ export const extractEmbeddedImage = async (
  * 指定されたパスの画像ファイルから Picture オブジェクトを生成して返します。
  * @param filePath 画像ファイルの絶対パス
  */
-export const getImageInfo = async (filePath: string): Promise<TagResult<Picture>> => {
+export const getImageInfo = async (filePath: string): Promise<AppResult<Picture>> => {
   return success({
     format: getMimeTypeFromPath(filePath),
     sourcePath: filePath,
@@ -42,7 +42,7 @@ export const getImageInfo = async (filePath: string): Promise<TagResult<Picture>
  * 画像ファイル選択ダイアログを表示し、選択された画像のパス情報を返します。
  * @returns 選択された画像のパス情報。キャンセルされた場合は Result(null)。
  */
-export const pickImage = async (): Promise<TagResult<Picture | null>> => {
+export const pickImage = async (): Promise<AppResult<Picture | null>> => {
   const filePath = await pickImageFile();
 
   if (!filePath) {

--- a/src/main/services/flac/reader.ts
+++ b/src/main/services/flac/reader.ts
@@ -1,9 +1,9 @@
 import { success } from '@domain/common/result';
-import { TagResult } from '@domain/flac/types';
-import { tagErrors } from '@domain/flac/errors';
+import { AppResult } from '@domain/flac/types';
+import { appErrors } from '@domain/flac/errors';
 import { FlacTrack } from '@domain/flac/models';
 import * as readerImpl from 'music-metadata';
-import { toTagResultFailure } from '@main/utils/error-handler';
+import { toAppResultFailure } from '@main/utils/error-handler';
 import { ensureFileExists } from '@main/utils/fs';
 import { mapToFlacMetadata, toRawFlacData } from './mappers/flac-read-mapper';
 import { RawFlacData } from './types';
@@ -13,14 +13,14 @@ import { RawFlacData } from './types';
  * メモリ節約のため、画像の存在確認のみを行い、バイナリデータ自体は戻り値に含めません。
  * 画像を実際に表示する場合は、カスタムプロトコル (flac-image://) を使用してください。
  */
-export const readMetadata = async (filePath: string): Promise<TagResult<FlacTrack>> => {
+export const readMetadata = async (filePath: string): Promise<AppResult<FlacTrack>> => {
   try {
     await ensureFileExists(filePath);
     const rawData = await readRawData(filePath);
     const metadata = mapToFlacMetadata(rawData, filePath);
     return success({ path: filePath, metadata });
   } catch (error: unknown) {
-    return toTagResultFailure(error, tagErrors.parseFailed, { path: filePath });
+    return toAppResultFailure(error, appErrors.parseFailed, { path: filePath });
   }
 };
 

--- a/src/main/services/flac/renamer.ts
+++ b/src/main/services/flac/renamer.ts
@@ -1,11 +1,11 @@
 import { success } from '@domain/common/result';
-import { TagResult } from '@domain/flac/types';
-import { tagErrors } from '@domain/flac/errors';
+import { AppResult } from '@domain/flac/types';
+import { appErrors } from '@domain/flac/errors';
 import type { FlacTrack } from '@domain/flac/models';
 import { formatFlacFilename } from '@domain/flac/filename-formatter';
 import path from 'path';
 import fs from 'fs/promises';
-import { toTagResultFailure } from '@main/utils/error-handler';
+import { toAppResultFailure } from '@main/utils/error-handler';
 import { ensureFileExists } from '@main/utils/fs';
 import { settingsRepository } from '@main/infrastructure/repositories/settings-repository';
 
@@ -14,7 +14,7 @@ import { settingsRepository } from '@main/infrastructure/repositories/settings-r
  * @param oldPath 現在の絶対パス
  * @param newPath 新しい絶対パス
  */
-export const renameFile = async (oldPath: string, newPath: string): Promise<TagResult<void>> => {
+export const renameFile = async (oldPath: string, newPath: string): Promise<AppResult<void>> => {
   if (oldPath === newPath) {
     return success(undefined);
   }
@@ -26,7 +26,7 @@ export const renameFile = async (oldPath: string, newPath: string): Promise<TagR
   try {
     await fs.rename(oldPath, newPath);
   } catch (error: unknown) {
-    return toTagResultFailure(error, tagErrors.writeFailed, { path: oldPath });
+    return toAppResultFailure(error, appErrors.writeFailed, { path: oldPath });
   }
 
   return success(undefined);
@@ -36,7 +36,7 @@ export const renameFile = async (oldPath: string, newPath: string): Promise<TagR
  * トラックのメタデータに基づいて、リネーム後のフルパスを算出します。
  * @param track トラック情報
  */
-export const resolveRenamedPath = (track: FlacTrack): TagResult<string> => {
+export const resolveRenamedPath = (track: FlacTrack): AppResult<string> => {
   const { renamePattern, trackNumberPadding } = settingsRepository.settings;
   const filenameResult = formatFlacFilename(track, {
     pattern: renamePattern,

--- a/src/main/services/flac/scanner.ts
+++ b/src/main/services/flac/scanner.ts
@@ -1,10 +1,10 @@
 import { success } from '@domain/common/result';
 import { ResolvedPath } from '@domain/common/system';
-import { ScanResult, TagResult } from '@domain/flac/types';
-import { tagErrors } from '@domain/flac/errors';
+import { ScanResult, AppResult } from '@domain/flac/types';
+import { appErrors } from '@domain/flac/errors';
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { toTagResultFailure } from '@main/utils/error-handler';
+import { toAppResultFailure } from '@main/utils/error-handler';
 import { determinePathType, resolvePaths } from './path-resolver';
 
 /**
@@ -26,13 +26,13 @@ interface ScanContext {
  * @param targetPaths 探索対象のパスの配列
  * @returns 見つかった FLAC ファイルの絶対パスの配列と制限フラグを含むオブジェクト
  */
-export const scanDirectory = async (targetPaths: string[]): Promise<TagResult<ScanResult>> => {
+export const scanDirectory = async (targetPaths: string[]): Promise<AppResult<ScanResult>> => {
   try {
     const result = await collectTracksFromPaths(targetPaths);
     return success({ paths: formatResultPaths(result.paths), isLimited: result.isLimited });
   } catch (error: unknown) {
     const representativePath = targetPaths[0] ?? '';
-    return toTagResultFailure(error, tagErrors.scanFailed, { path: representativePath });
+    return toAppResultFailure(error, appErrors.scanFailed, { path: representativePath });
   }
 };
 

--- a/src/main/services/flac/writer.ts
+++ b/src/main/services/flac/writer.ts
@@ -1,10 +1,10 @@
 import { failure, success } from '@domain/common/result';
-import { TagResult } from '@domain/flac/types';
-import { tagErrors } from '@domain/flac/errors';
+import { AppResult } from '@domain/flac/types';
+import { appErrors } from '@domain/flac/errors';
 import { FlacMetadata, FlacTrack } from '@domain/flac/models';
 import { writeFlacTags } from 'flac-tagger';
 import fs from 'node:fs/promises';
-import { hasErrorCode, toTagResultFailure } from '@main/utils/error-handler';
+import { hasErrorCode, toAppResultFailure } from '@main/utils/error-handler';
 import { withAtomicWrite } from '@main/utils/file-utils';
 import { mergeMetadataWithTags } from './mappers/flac-write-mapper';
 import { resolvePictureForWrite } from './mappers/flac-write-picture-resolver';
@@ -13,7 +13,7 @@ import { readRawData } from './reader';
 /**
  * 指定されたパスのFLACファイルへメタデータを書き込みます。
  */
-export const writeMetadata = async (track: FlacTrack): Promise<TagResult<void>> => {
+export const writeMetadata = async (track: FlacTrack): Promise<AppResult<void>> => {
   const { path, metadata } = track;
   // 1. バリデーション
   const existResult = await ensureFileExists(path);
@@ -30,7 +30,7 @@ export const writeMetadata = async (track: FlacTrack): Promise<TagResult<void>> 
   try {
     await performWrite(path, metadata);
   } catch (error: unknown) {
-    return toTagResultFailure(error, tagErrors.writeFailed, { path });
+    return toAppResultFailure(error, appErrors.writeFailed, { path });
   }
 
   return success(undefined);
@@ -39,14 +39,14 @@ export const writeMetadata = async (track: FlacTrack): Promise<TagResult<void>> 
 /**
  * ファイルが存在することを確認します。
  */
-const ensureFileExists = async (path: string): Promise<TagResult<void>> => {
+const ensureFileExists = async (path: string): Promise<AppResult<void>> => {
   try {
     await fs.access(path);
   } catch (error: unknown) {
     if (hasErrorCode(error, 'ENOENT')) {
-      return failure(tagErrors.fileNotFound({ path }));
+      return failure(appErrors.fileNotFound({ path }));
     }
-    return toTagResultFailure(error, tagErrors.writeFailed, { path });
+    return toAppResultFailure(error, appErrors.writeFailed, { path });
   }
 
   return success(undefined);
@@ -55,14 +55,14 @@ const ensureFileExists = async (path: string): Promise<TagResult<void>> => {
 /**
  * ファイルが書き込み可能であることを確認します。
  */
-const ensureFileWritable = async (path: string): Promise<TagResult<void>> => {
+const ensureFileWritable = async (path: string): Promise<AppResult<void>> => {
   try {
     await fs.access(path, fs.constants.W_OK);
   } catch (error: unknown) {
     if (hasErrorCode(error, 'EACCES') || hasErrorCode(error, 'EPERM')) {
-      return failure(tagErrors.permissionDenied({ path, detail: '(Read-only file)' }));
+      return failure(appErrors.permissionDenied({ path, detail: '(Read-only file)' }));
     }
-    return toTagResultFailure(error, tagErrors.writeFailed, { path });
+    return toAppResultFailure(error, appErrors.writeFailed, { path });
   }
 
   return success(undefined);

--- a/src/main/utils/error-handler.test.ts
+++ b/src/main/utils/error-handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { hasErrorCode, toTagResultFailure } from './error-handler';
-import { tagErrors } from '@domain/flac/errors';
+import { hasErrorCode, toAppResultFailure } from './error-handler';
+import { appErrors } from '@domain/flac/errors';
 
 describe('error-handler', () => {
   afterEach(() => {
@@ -30,14 +30,14 @@ describe('error-handler', () => {
     });
   });
 
-  describe('toTagResultFailure', () => {
+  describe('toAppResultFailure', () => {
     const path = '/test/path.flac';
-    const factory = tagErrors.fileNotFound;
+    const factory = appErrors.fileNotFound;
 
-    it('Error オブジェクトを TagResult の Failure（失敗）に正しく変換できること', () => {
+    it('Error オブジェクトを AppResult の Failure（失敗）に正しく変換できること', () => {
       const error = new Error('Original error message');
 
-      const result = toTagResultFailure(error, factory, { path });
+      const result = toAppResultFailure(error, factory, { path });
 
       expect(result.type).toBe('error');
       if (result.type === 'error') {
@@ -47,10 +47,10 @@ describe('error-handler', () => {
       }
     });
 
-    it('文字列のエラーメッセージを TagResult の Failure に正しく変換できること', () => {
+    it('文字列のエラーメッセージを AppResult の Failure に正しく変換できること', () => {
       const error = 'Something went wrong';
 
-      const result = toTagResultFailure(error, factory, { path });
+      const result = toAppResultFailure(error, factory, { path });
 
       expect(result.type).toBe('error');
       if (result.type === 'error') {

--- a/src/main/utils/error-handler.ts
+++ b/src/main/utils/error-handler.ts
@@ -1,6 +1,6 @@
 import { failure } from '@domain/common/result';
-import { TagResult } from '@domain/flac/types';
-import { TagError, TagErrorOptions } from '@domain/flac/errors';
+import { AppResult } from '@domain/flac/types';
+import { AppError, AppErrorOptions } from '@domain/flac/errors';
 
 /**
  * 指定されたエラーコードを持つエラーオブジェクトかどうかを判定します（Type Guard）。
@@ -15,19 +15,19 @@ export const hasErrorCode = (error: unknown, code: string): error is { code: str
 };
 
 /**
- * catch 句で受け取った error: unknown を、TagResult の failure に変換します。
+ * catch 句で受け取った error: unknown を、AppResult の failure に変換します。
  * @param error 発生したエラー
- * @param factory TagError を生成する関数
+ * @param factory AppError を生成する関数
  * @param options 追加のコンテキスト情報
- * @returns Failure<TagError> を含む TagResult オブジェクト
+ * @returns Failure<AppError> を含む AppResult オブジェクト
  */
-export const toTagResultFailure = <T>(
+export const toAppResultFailure = <T>(
   error: unknown,
-  factory: (options: TagErrorOptions) => TagError,
-  options: TagErrorOptions
-): TagResult<T> => {
+  factory: (options: AppErrorOptions) => AppError,
+  options: AppErrorOptions
+): AppResult<T> => {
   const message = error instanceof Error ? error.message : String(error);
-  const tagError = factory({ ...options, detail: message });
+  const appError = factory({ ...options, detail: message });
 
-  return failure(tagError);
+  return failure(appError);
 };

--- a/src/renderer/src/infrastructure/adapters/path-adapter.ts
+++ b/src/renderer/src/infrastructure/adapters/path-adapter.ts
@@ -1,4 +1,4 @@
-import type { TagResult } from '@domain/flac/types';
+import type { AppResult } from '@domain/flac/types';
 import type { FlacTrack } from '@domain/flac/models';
 
 /**
@@ -10,6 +10,6 @@ import type { FlacTrack } from '@domain/flac/models';
  * @param track トラック情報
  * @returns 生成された新しいフルパス
  */
-export const generateNewPath = async (track: FlacTrack): Promise<TagResult<string>> => {
+export const generateNewPath = async (track: FlacTrack): Promise<AppResult<string>> => {
   return await window.api.generateNewPath(track);
 };

--- a/src/renderer/src/infrastructure/repositories/file-repository.ts
+++ b/src/renderer/src/infrastructure/repositories/file-repository.ts
@@ -1,9 +1,9 @@
-import type { TagResult } from '@domain/flac/types';
+import type { AppResult } from '@domain/flac/types';
 
 /**
  * 物理的なファイル操作（リネームなど）を担当するリポジトリ。
  */
-const renameFile = async (oldPath: string, newPath: string): Promise<TagResult<void>> => {
+const renameFile = async (oldPath: string, newPath: string): Promise<AppResult<void>> => {
   return await window.api.renameFile(oldPath, newPath);
 };
 

--- a/src/renderer/src/infrastructure/repositories/settings-repository.ts
+++ b/src/renderer/src/infrastructure/repositories/settings-repository.ts
@@ -1,15 +1,15 @@
-import type { TagResult } from '@domain/flac/types';
+import type { AppResult } from '@domain/flac/types';
 import type { AppSettings } from '@shared/settings';
 
 /**
  * アプリケーション設定の永続化・取得を担当するリポジトリ。
  * Electron IPC経由でメインプロセスの SettingsStore と通信します。
  */
-const getSettings = async (): Promise<TagResult<AppSettings>> => {
+const getSettings = async (): Promise<AppResult<AppSettings>> => {
   return await window.api.getSettings();
 };
 
-const updateSettings = async (settings: Partial<AppSettings>): Promise<TagResult<void>> => {
+const updateSettings = async (settings: Partial<AppSettings>): Promise<AppResult<void>> => {
   return await window.api.updateSettings(settings);
 };
 

--- a/src/renderer/src/infrastructure/repositories/tag-repository.test.ts
+++ b/src/renderer/src/infrastructure/repositories/tag-repository.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { tagRepository } from './tag-repository';
 import { success, failure } from '@domain/common/result';
 import type { FlacTrack } from '@domain/flac/models';
-import type { TagError } from '@domain/flac/errors';
+import type { AppError } from '@domain/flac/errors';
 
 describe('tag-repository', () => {
   beforeEach(() => {
@@ -53,7 +53,7 @@ describe('tag-repository', () => {
     });
 
     it('スキャンに失敗した場合はエラーを返すこと', async () => {
-      const error: TagError = {
+      const error: AppError = {
         type: 'SCAN_FAILED',
         options: { path: '/dir' }
       };
@@ -81,7 +81,7 @@ describe('tag-repository', () => {
     });
 
     it('一部が失敗しても全ての保存を試行し、最初のエラーを返すこと', async () => {
-      const error: TagError = {
+      const error: AppError = {
         type: 'WRITE_FAILED',
         options: { path: 'b.flac' }
       };

--- a/src/renderer/src/infrastructure/repositories/tag-repository.ts
+++ b/src/renderer/src/infrastructure/repositories/tag-repository.ts
@@ -1,5 +1,5 @@
 import { success } from '@domain/common/result';
-import type { TagResult } from '@domain/flac/types';
+import type { AppResult } from '@domain/flac/types';
 import type { FlacTrack, Picture } from '@domain/flac/models';
 import { pooledAll } from '@renderer/utils/concurrency';
 
@@ -8,13 +8,13 @@ import { pooledAll } from '@renderer/utils/concurrency';
  * Electron IPC経由でメインプロセスのサービスと通信します。
  */
 
-const readMetadata = async (path: string): Promise<TagResult<FlacTrack>> => {
+const readMetadata = async (path: string): Promise<AppResult<FlacTrack>> => {
   return await window.api.readMetadata(path);
 };
 
 const loadTracksFromPaths = async (
   targetPaths: string[]
-): Promise<TagResult<{ tracks: FlacTrack[]; isLimited: boolean }>> => {
+): Promise<AppResult<{ tracks: FlacTrack[]; isLimited: boolean }>> => {
   const scanResult = await window.api.scanDirectory(targetPaths);
   if (scanResult.type === 'error') {
     return scanResult;
@@ -35,7 +35,7 @@ const loadTracksFromPaths = async (
 };
 
 const scanAndLoadTracks = async (): Promise<
-  TagResult<{ tracks: FlacTrack[]; isLimited: boolean } | null>
+  AppResult<{ tracks: FlacTrack[]; isLimited: boolean } | null>
 > => {
   const dirPath = await window.api.selectDirectory();
   if (!dirPath) {
@@ -44,7 +44,7 @@ const scanAndLoadTracks = async (): Promise<
   return await loadTracksFromPaths([dirPath]);
 };
 
-const saveTracks = async (tracks: FlacTrack[]): Promise<TagResult<void>> => {
+const saveTracks = async (tracks: FlacTrack[]): Promise<AppResult<void>> => {
   const results = await pooledAll(tracks.map((track) => () => window.api.writeMetadata(track)));
 
   for (const result of results) {
@@ -56,11 +56,11 @@ const saveTracks = async (tracks: FlacTrack[]): Promise<TagResult<void>> => {
   return success(undefined);
 };
 
-const pickImage = async (): Promise<TagResult<Picture | null>> => {
+const pickImage = async (): Promise<AppResult<Picture | null>> => {
   return await window.api.pickImage();
 };
 
-const getImageInfo = async (path: string): Promise<TagResult<Picture>> => {
+const getImageInfo = async (path: string): Promise<AppResult<Picture>> => {
   return await window.api.getImageInfo(path);
 };
 

--- a/src/renderer/src/services/file-actions.test.ts
+++ b/src/renderer/src/services/file-actions.test.ts
@@ -7,7 +7,7 @@ import { tagRepository } from '@renderer/infrastructure/repositories/tag-reposit
 import { fileRepository } from '@renderer/infrastructure/repositories/file-repository';
 import { success, failure } from '@domain/common/result';
 import { TrackRecord } from '@renderer/stores/track-record.svelte';
-import { tagErrors } from '@domain/flac/errors';
+import { appErrors } from '@domain/flac/errors';
 import type { FlacMetadata, FlacTrack } from '@domain/flac/models';
 import * as pathAdapter from '@renderer/infrastructure/adapters/path-adapter';
 
@@ -62,7 +62,7 @@ describe('fileActions', () => {
       selectionState.selectSingle(mockTrack, 0);
 
       vi.mocked(pathAdapter.generateNewPath).mockResolvedValue(
-        failure(tagErrors.parseFailed({ path: 'old.flac' }))
+        failure(appErrors.parseFailed({ path: 'old.flac' }))
       );
 
       await fileActions.renameSelectedFiles();

--- a/src/renderer/src/services/file-actions.ts
+++ b/src/renderer/src/services/file-actions.ts
@@ -1,5 +1,5 @@
 import { success, type Result } from '@domain/common/result';
-import type { TagError } from '@domain/flac/errors';
+import type { AppError } from '@domain/flac/errors';
 import { generateNewPath } from '@renderer/infrastructure/adapters/path-adapter';
 import { fileRepository } from '@renderer/infrastructure/repositories/file-repository';
 import { tagRepository } from '@renderer/infrastructure/repositories/tag-repository';
@@ -58,7 +58,7 @@ const executeRenameLoop = async (selected: TrackRecord[]): Promise<Map<string, T
  * 単一のトラックに対して、ファイル名生成、パス計算、リネーム実行、再読み込みの一連の処理を行います。
  * 成功した場合は新しい TrackRecord を返し、スキップ（変更不要など）時は null を返します。
  */
-const renameTrack = async (track: TrackRecord): Promise<Result<TrackRecord | null, TagError>> => {
+const renameTrack = async (track: TrackRecord): Promise<Result<TrackRecord | null, AppError>> => {
   // 1. メタデータに基づいた新しいパスの生成（フォーマットとパス結合を一括で行う）
   const pathResult = await generateNewPath(track.toFlacTrack());
   if (pathResult.type === 'error') {

--- a/src/renderer/src/services/tag-actions.test.ts
+++ b/src/renderer/src/services/tag-actions.test.ts
@@ -9,7 +9,7 @@ import { tagEditor } from './tag-editor';
 import type { FlacMetadata } from '@domain/flac/models';
 import { logStore } from '@renderer/stores/log-store.svelte';
 import { failure, success } from '@domain/common/result';
-import type { TagError } from '@domain/flac/errors';
+import type { AppError } from '@domain/flac/errors';
 
 vi.mock('@renderer/stores/log-store.svelte', () => ({
   logStore: {
@@ -201,7 +201,7 @@ describe('tagActions', () => {
 
   describe('error and edge cases', () => {
     it('スキャンエラー時にレンダラー側でログを重複して記録しないこと', async () => {
-      const error: TagError = { type: 'SCAN_FAILED', options: { path: '/dir' } };
+      const error: AppError = { type: 'SCAN_FAILED', options: { path: '/dir' } };
       vi.mocked(tagRepository.loadTracksFromPaths).mockResolvedValue(failure(error));
 
       await tagActions.loadFromPaths(['/dir']);
@@ -222,7 +222,7 @@ describe('tagActions', () => {
     });
 
     it('一括保存エラー時にレンダラー側でログを重複して記録しないこと', async () => {
-      const error: TagError = { type: 'WRITE_FAILED', options: { path: 'a.flac' } };
+      const error: AppError = { type: 'WRITE_FAILED', options: { path: 'a.flac' } };
       vi.mocked(tagRepository.saveTracks).mockResolvedValue(failure(error));
       trackStore.tracks = [new TrackRecord('a.flac', {})];
       trackStore.tracks[0].metadata.title = 'New';
@@ -233,7 +233,7 @@ describe('tagActions', () => {
     });
 
     it('画像選択エラー時にレンダラー側でログを重複して記録しないこと', async () => {
-      const error: TagError = { type: 'PICK_IMAGE_FAILED', options: { path: '' } };
+      const error: AppError = { type: 'PICK_IMAGE_FAILED', options: { path: '' } };
       vi.spyOn(tagRepository, 'pickImage').mockResolvedValue(failure(error));
 
       await tagActions.pickAndApplyPicture();

--- a/src/renderer/src/services/tag-actions.ts
+++ b/src/renderer/src/services/tag-actions.ts
@@ -1,6 +1,6 @@
 import { MESSAGES } from '@domain/common/messages';
 import type { EditableMultiKey, EditableSingleKey } from '@domain/editor/batch-metadata';
-import type { TagResult } from '@domain/flac/types';
+import type { AppResult } from '@domain/flac/types';
 import type { FlacTrack } from '@domain/flac/models';
 import { tagRepository } from '@renderer/infrastructure/repositories/tag-repository';
 import { logStore } from '@renderer/stores/log-store.svelte';
@@ -13,7 +13,7 @@ import { tagEditor } from './tag-editor';
  * スキャン処理の共通的なフローを制御するヘルパー関数。
  */
 const handleScanOperation = async (
-  operation: () => Promise<TagResult<{ tracks: FlacTrack[]; isLimited: boolean } | null>>
+  operation: () => Promise<AppResult<{ tracks: FlacTrack[]; isLimited: boolean } | null>>
 ): Promise<void> => {
   uiState.startLoading();
 

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1,5 +1,5 @@
 import type { LogHandler } from '@domain/common/log';
-import type { ScanResult, TagResult } from '@domain/flac/types';
+import type { ScanResult, AppResult } from '@domain/flac/types';
 import type { FlacTrack, Picture } from '@domain/flac/models';
 import type { Platform } from './platform';
 import type { AppSettings } from './settings';
@@ -47,29 +47,29 @@ export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];
  */
 export interface IpcApi {
   /** 指定されたパスの FLAC メタデータを読み取ります */
-  readMetadata: (filePath: string) => Promise<TagResult<FlacTrack>>;
+  readMetadata: (filePath: string) => Promise<AppResult<FlacTrack>>;
   /** 指定されたパスの FLAC メタデータを書き込みます */
-  writeMetadata: (track: FlacTrack) => Promise<TagResult<void>>;
+  writeMetadata: (track: FlacTrack) => Promise<AppResult<void>>;
   /** フォルダ選択ダイアログを表示し、選択されたパスを返します */
   selectDirectory: () => Promise<string | null>;
   /** 指定されたパス（ファイルまたはディレクトリ）内のFLACファイルのパスリストを返します */
-  scanDirectory: (targetPaths: string[]) => Promise<TagResult<ScanResult>>;
+  scanDirectory: (targetPaths: string[]) => Promise<AppResult<ScanResult>>;
   /** 画像ファイルを選択し、メタデータ用の Picture オブジェクトを返します */
-  pickImage: () => Promise<TagResult<Picture | null>>;
+  pickImage: () => Promise<AppResult<Picture | null>>;
   /** 指定したパスの画像ファイルから Picture オブジェクトを生成して返します */
-  getImageInfo: (filePath: string) => Promise<TagResult<Picture>>;
+  getImageInfo: (filePath: string) => Promise<AppResult<Picture>>;
   /** ファイルをリネーム（移動）します */
-  renameFile: (oldPath: string, newPath: string) => Promise<TagResult<void>>;
+  renameFile: (oldPath: string, newPath: string) => Promise<AppResult<void>>;
   /** メタデータに基づいて新しいファイルパスを生成します */
-  generateNewPath: (track: FlacTrack) => Promise<TagResult<string>>;
+  generateNewPath: (track: FlacTrack) => Promise<AppResult<string>>;
   /** File オブジェクトから OS 上のファイルシステムパスを取得します */
   getPathForFile: (file: File) => string;
   /** 実行環境のプラットフォームを取得します */
   getPlatform: () => Promise<Platform>;
   /** アプリケーション設定を取得します */
-  getSettings: () => Promise<TagResult<AppSettings>>;
+  getSettings: () => Promise<AppResult<AppSettings>>;
   /** アプリケーション設定を更新します */
-  updateSettings: (settings: Partial<AppSettings>) => Promise<TagResult<void>>;
+  updateSettings: (settings: Partial<AppSettings>) => Promise<AppResult<void>>;
   /** ログメッセージを受信した時のコールバックを登録します */
   onLogMessage: (callback: LogHandler) => Unsubscribe;
 }


### PR DESCRIPTION
GitHub issue #140 に対応するため、以下の変更を行いました。

### 変更内容
`TagResult` および `TagError` がタグ編集以外の文脈（設定の読み書きやファイル操作など）でも使用されるようになったため、より汎用的な名称に変更しました。

- `TagResult` → `AppResult`
- `TagError` → `AppError`
- `TagErrorType` → `AppErrorType`
- `TagErrorOptions` → `AppErrorOptions`
- `isTagError` → `isAppError`
- `tagErrors` → `appErrors`
- `TAG_ERROR_TYPES` → `APP_ERROR_TYPES`
- `toTagResultFailure` → `toAppResultFailure`
- `formatTagError` → `formatAppError`
- `MESSAGES.TAG_ERRORS` → `MESSAGES.APP_ERRORS`
- ファイルのリネーム: `src/domain/flac/tag-error-formatter.ts` → `src/domain/flac/app-error-formatter.ts`

### 検証内容
- 全ての型定義が正しく更新され、ビルドが通ることを確認。
- ユニットテストを全て実行し、リネーム後も正常にパスすることを確認。
- `pnpm lint` により、静的解析エラーがないことを確認。

Closes #140