### PR TITLE
build: electron-updaterをバンドル対象から除外

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -6,13 +6,7 @@ export default defineConfig({
   main: {
     build: {
       externalizeDeps: {
-        exclude: [
-          'flac-tagger',
-          'music-metadata',
-          'fast-equals',
-          'electron-updater',
-          '@electron-toolkit/utils'
-        ]
+        exclude: ['flac-tagger', 'music-metadata', 'fast-equals', '@electron-toolkit/utils']
       }
     },
     resolve: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",


### PR DESCRIPTION
## 概要
GitHub issue #161 に基づき、`electron-updater` をビルド時のバンドル対象から除外（externalize）しました。

## 変更内容
- `electron.vite.config.ts` の `main.build.externalizeDeps.exclude` 配列から `'electron-updater'` を削除しました。
- `package.json` のバージョンを `1.1.8` に更新しました。

## 検証内容
- `pnpm format`: 正常終了
- `pnpm lint`: 正常終了
- `pnpm build`: 正常終了
- `pnpm test`: 実行しましたが、既存のテスト（`settings-store.svelte.test.ts`）に起因するエラーが1件発生しました。このエラーは今回の変更を適用する前の状態でも発生することを確認済みであり、本PRの変更とは無関係です。