### PR TITLE
style: ログ表示の整形と列の整列 (#159)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.2.2",
+  "version": "1.2.1",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/main/ipc/event-forwarder.ts
+++ b/src/main/ipc/event-forwarder.ts
@@ -9,6 +9,6 @@ import { IPC_CHANNELS } from '@shared/ipc';
 export const initializeEventForwarding = (): void => {
   // ログイベントの転送
   logger.onLog((logMessage) => {
-    windowAdapter.sendToAllWindows(IPC_CHANNELS.ON_LOG_MESSAGE, logMessage);
+    windowAdapter.sendToAllWindows(IPC_CHANNELS.ON_LOG, logMessage);
   });
 };

--- a/src/main/ipc/flac-handlers.ts
+++ b/src/main/ipc/flac-handlers.ts
@@ -11,38 +11,34 @@ import { ipcMain } from 'electron';
 /** FLAC関連のIPCハンドラーを登録 */
 export const registerFlacHandlers = (): void => {
   // メタデータの読み取り
-  ipcMain.handle(IPC_CHANNELS.READ_METADATA, async (_event, filePath: string) => {
-    return withResultLogging(IPC_CHANNELS.READ_METADATA, () => readMetadata(filePath), filePath);
+  ipcMain.handle(IPC_CHANNELS.READ_TAG, async (_event, filePath: string) => {
+    return withResultLogging(IPC_CHANNELS.READ_TAG, () => readMetadata(filePath), filePath);
   });
 
   // メタデータの書き込み
-  ipcMain.handle(IPC_CHANNELS.WRITE_METADATA, async (_event, track: FlacTrack) => {
-    return withResultLogging(IPC_CHANNELS.WRITE_METADATA, () => writeMetadata(track), track.path);
+  ipcMain.handle(IPC_CHANNELS.WRITE_TAG, async (_event, track: FlacTrack) => {
+    return withResultLogging(IPC_CHANNELS.WRITE_TAG, () => writeMetadata(track), track.path);
   });
 
   // ディレクトリのスキャン
-  ipcMain.handle(IPC_CHANNELS.SCAN_DIRECTORY, async (_event, targetPaths: string[]) => {
-    return withResultLogging(
-      IPC_CHANNELS.SCAN_DIRECTORY,
-      () => scanDirectory(targetPaths),
-      targetPaths
-    );
+  ipcMain.handle(IPC_CHANNELS.SCAN_DIR, async (_event, targetPaths: string[]) => {
+    return withResultLogging(IPC_CHANNELS.SCAN_DIR, () => scanDirectory(targetPaths), targetPaths);
   });
 
   // 画像の選択
-  ipcMain.handle(IPC_CHANNELS.PICK_IMAGE, async () => {
-    return withResultLogging(IPC_CHANNELS.PICK_IMAGE, () => pickImage());
+  ipcMain.handle(IPC_CHANNELS.PICK_IMG, async () => {
+    return withResultLogging(IPC_CHANNELS.PICK_IMG, () => pickImage());
   });
 
   // 画像情報の取得
-  ipcMain.handle(IPC_CHANNELS.GET_IMAGE_INFO, async (_event, filePath: string) => {
-    return withResultLogging(IPC_CHANNELS.GET_IMAGE_INFO, () => getImageInfo(filePath), filePath);
+  ipcMain.handle(IPC_CHANNELS.IMG_INFO, async (_event, filePath: string) => {
+    return withResultLogging(IPC_CHANNELS.IMG_INFO, () => getImageInfo(filePath), filePath);
   });
 
   // ファイルのリネーム
-  ipcMain.handle(IPC_CHANNELS.RENAME_FILE, async (_event, oldPath: string, newPath: string) => {
+  ipcMain.handle(IPC_CHANNELS.RENAME, async (_event, oldPath: string, newPath: string) => {
     return withResultLogging(
-      IPC_CHANNELS.RENAME_FILE,
+      IPC_CHANNELS.RENAME,
       () => renameFile(oldPath, newPath),
       oldPath,
       newPath
@@ -50,9 +46,9 @@ export const registerFlacHandlers = (): void => {
   });
 
   // 新しいパスの生成
-  ipcMain.handle(IPC_CHANNELS.GENERATE_NEW_PATH, async (_event, track: FlacTrack) => {
+  ipcMain.handle(IPC_CHANNELS.GEN_PATH, async (_event, track: FlacTrack) => {
     return withResultLogging(
-      IPC_CHANNELS.GENERATE_NEW_PATH,
+      IPC_CHANNELS.GEN_PATH,
       async () => resolveRenamedPath(track),
       track.path
     );

--- a/src/main/ipc/platform-handlers.ts
+++ b/src/main/ipc/platform-handlers.ts
@@ -8,12 +8,12 @@ import { ipcMain } from 'electron';
  */
 export const registerPlatformHandlers = (): void => {
   // フォルダ選択ダイアログを表示
-  ipcMain.handle(IPC_CHANNELS.SELECT_DIRECTORY, async () => {
+  ipcMain.handle(IPC_CHANNELS.SELECT_DIR, async () => {
     return await selectDirectory();
   });
 
   // プラットフォームを取得
-  ipcMain.handle(IPC_CHANNELS.GET_PLATFORM, () => {
+  ipcMain.handle(IPC_CHANNELS.PLATFORM, () => {
     return getPlatform();
   });
 };

--- a/src/main/ipc/settings-handlers.ts
+++ b/src/main/ipc/settings-handlers.ts
@@ -9,14 +9,14 @@ import { withResultLogging } from '@main/infrastructure/logging/result-logging';
  * 設定に関連する IPC ハンドラを登録します。
  */
 export const registerSettingsHandlers = (): void => {
-  ipcMain.handle(IPC_CHANNELS.GET_SETTINGS, async () => {
-    return withResultLogging(IPC_CHANNELS.GET_SETTINGS, async () =>
+  ipcMain.handle(IPC_CHANNELS.GET_CONFIG, async () => {
+    return withResultLogging(IPC_CHANNELS.GET_CONFIG, async () =>
       success(settingsRepository.settings)
     );
   });
 
-  ipcMain.handle(IPC_CHANNELS.UPDATE_SETTINGS, async (_, settings: Partial<AppSettings>) => {
-    return withResultLogging(IPC_CHANNELS.UPDATE_SETTINGS, async () => {
+  ipcMain.handle(IPC_CHANNELS.UPDATE_CONFIG, async (_, settings: Partial<AppSettings>) => {
+    return withResultLogging(IPC_CHANNELS.UPDATE_CONFIG, async () => {
       settingsRepository.updateSettings(settings);
       return success(undefined);
     });

--- a/src/main/ipc/window-handlers.ts
+++ b/src/main/ipc/window-handlers.ts
@@ -6,7 +6,7 @@ import { showMainWindow } from '@services/platform/window';
  * ウィンドウ操作に関する IPC ハンドラを登録します。
  */
 export const registerWindowHandlers = (): void => {
-  ipcMain.handle(IPC_CHANNELS.SHOW_MAIN_WINDOW, (event) => {
+  ipcMain.handle(IPC_CHANNELS.SHOW_MAIN, (event) => {
     showMainWindow(event.sender);
   });
 };

--- a/src/preload/api.ts
+++ b/src/preload/api.ts
@@ -15,63 +15,62 @@ export const api: IpcApi = {
    * FLACファイルのメタデータを読み取ります。
    * @param path ファイルの絶対パス
    */
-  readMetadata: (path: string) => ipcRenderer.invoke(IPC_CHANNELS.READ_METADATA, path),
+  readMetadata: (path: string) => ipcRenderer.invoke(IPC_CHANNELS.READ_TAG, path),
   /**
    * FLACファイルのメタデータを書き込みます。
    * @param track 書き込むトラック情報（パスとメタデータ）
    */
-  writeMetadata: (track: FlacTrack) => ipcRenderer.invoke(IPC_CHANNELS.WRITE_METADATA, track),
+  writeMetadata: (track: FlacTrack) => ipcRenderer.invoke(IPC_CHANNELS.WRITE_TAG, track),
   /**
    * フォルダ選択ダイアログを表示します。
    */
-  selectDirectory: () => ipcRenderer.invoke(IPC_CHANNELS.SELECT_DIRECTORY),
+  selectDirectory: () => ipcRenderer.invoke(IPC_CHANNELS.SELECT_DIR),
   /**
    * 指定したパス（ファイルまたはディレクトリ）内のFLACファイルをスキャンします。
    * @param targetPaths ファイルまたはディレクトリの絶対パスの配列
    */
-  scanDirectory: (targetPaths: string[]) =>
-    ipcRenderer.invoke(IPC_CHANNELS.SCAN_DIRECTORY, targetPaths),
+  scanDirectory: (targetPaths: string[]) => ipcRenderer.invoke(IPC_CHANNELS.SCAN_DIR, targetPaths),
   /**
    * 画像ファイルを選択し、メタデータ用の Picture オブジェクトを返します。
    */
-  pickImage: () => ipcRenderer.invoke(IPC_CHANNELS.PICK_IMAGE),
+  pickImage: () => ipcRenderer.invoke(IPC_CHANNELS.PICK_IMG),
   /**
    * 指定したパスの画像情報を取得します。
    * @param path 画像ファイルの絶対パス
    */
-  getImageInfo: (path: string) => ipcRenderer.invoke(IPC_CHANNELS.GET_IMAGE_INFO, path),
+  getImageInfo: (path: string) => ipcRenderer.invoke(IPC_CHANNELS.IMG_INFO, path),
   /**
    * ファイルをリネーム（移動）します。
    * @param oldPath 現在のパス
    * @param newPath 新しいパス
    */
   renameFile: (oldPath: string, newPath: string) =>
-    ipcRenderer.invoke(IPC_CHANNELS.RENAME_FILE, oldPath, newPath),
+    ipcRenderer.invoke(IPC_CHANNELS.RENAME, oldPath, newPath),
   /**
    * メタデータに基づいて新しいファイルパスを生成します。
    * @param track トラック情報
    */
-  generateNewPath: (track: FlacTrack) => ipcRenderer.invoke(IPC_CHANNELS.GENERATE_NEW_PATH, track),
+  generateNewPath: (track: FlacTrack) => ipcRenderer.invoke(IPC_CHANNELS.GEN_PATH, track),
   /**
    * File オブジェクトから OS 上のファイルシステムパスを取得します。
    * Electron v28+ で非推奨となった File.path の代替です。
    */
   getPathForFile: (file: File) => webUtils.getPathForFile(file),
-  getPlatform: () => ipcRenderer.invoke(IPC_CHANNELS.GET_PLATFORM),
+  getPlatform: () => ipcRenderer.invoke(IPC_CHANNELS.PLATFORM),
   /**
    * アプリケーション設定を取得します。
    */
-  getSettings: () => ipcRenderer.invoke(IPC_CHANNELS.GET_SETTINGS),
+  getSettings: () => ipcRenderer.invoke(IPC_CHANNELS.GET_CONFIG),
   /**
    * アプリケーション設定を更新します。
    * @param settings 更新する設定のサブセット
    */
   updateSettings: (settings: Partial<AppSettings>) =>
-    ipcRenderer.invoke(IPC_CHANNELS.UPDATE_SETTINGS, settings),
+    ipcRenderer.invoke(IPC_CHANNELS.UPDATE_CONFIG, settings),
   /**
    * メインウィンドウを表示します。
    */
-  showMainWindow: () => ipcRenderer.invoke(IPC_CHANNELS.SHOW_MAIN_WINDOW),
+  showMainWindow: () => ipcRenderer.invoke(IPC_CHANNELS.SHOW_MAIN),
   /**
    * ログメッセージを受信した時のコールバックを登録します。
    * @param callback ログメッセージを受け取るコールバック
@@ -79,8 +78,8 @@ export const api: IpcApi = {
    */
   onLogMessage: (callback: LogHandler) => {
     const subscription = (_: IpcRendererEvent, message: LogMessage): void => callback(message);
-    ipcRenderer.on(IPC_CHANNELS.ON_LOG_MESSAGE, subscription);
-    return () => ipcRenderer.removeListener(IPC_CHANNELS.ON_LOG_MESSAGE, subscription);
+    ipcRenderer.on(IPC_CHANNELS.ON_LOG, subscription);
+    return () => ipcRenderer.removeListener(IPC_CHANNELS.ON_LOG, subscription);
   }
 };
 

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -81,19 +81,33 @@
   {#if isExpanded}
     <div class="log-panel" transition:slide={{ duration: 300 }}>
       <div class="log-list" bind:this={logListElement}>
-        {#each logStore.logs as log (log.id)}
-          {@const ICON = levelIcons.get(log.level)}
-          <div class="log-entry {log.level.toLowerCase()}">
-            <span class="timestamp">[{formatTimeWithMs(log.timestamp)}]</span>
-            <div class="log-level-icon">
-              <ICON size={UI_TOKENS.icons.sizeSmall} />
-            </div>
-            <span class="log-text" use:tooltip={log.message}>
-              <span class="log-context">[{log.context}]</span>
-              {log.message}
-            </span>
-          </div>
-        {/each}
+        <table class="log-table">
+          <tbody>
+            {#each logStore.logs as log (log.id)}
+              {@const ICON = levelIcons.get(log.level)}
+              <tr class="log-entry {log.level.toLowerCase()}">
+                <td class="log-col-time">
+                  <span class="timestamp">[{formatTimeWithMs(log.timestamp)}]</span>
+                </td>
+                <td class="log-col-icon">
+                  <div class="log-level-icon">
+                    {#if ICON}
+                      <ICON size={UI_TOKENS.icons.sizeSmall} />
+                    {/if}
+                  </div>
+                </td>
+                <td class="log-col-context">
+                  <span class="log-context" use:tooltip={log.context}>[{log.context}]</span>
+                </td>
+                <td class="log-col-message">
+                  <span class="log-text" use:tooltip={log.message}>
+                    {log.message}
+                  </span>
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
       </div>
     </div>
   {/if}
@@ -172,6 +186,11 @@
   .log-context {
     color: var(--text-muted);
     font-weight: 500;
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: bottom;
   }
 
   .expand-icon {
@@ -203,24 +222,20 @@
   .log-list {
     flex: 1;
     overflow: auto;
-    padding: 0.5rem;
+    padding: 0.25rem 0.5rem;
     font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
     font-size: 0.75rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.1rem;
+  }
+
+  .log-table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
   }
 
   .log-entry {
-    display: flex;
-    gap: 0.75rem;
-    align-items: center;
     font-size: 0.7rem;
     line-height: 1.5;
-    padding: 0.15rem 0.4rem;
-    border-radius: 2px;
-    width: fit-content;
-    min-width: 100%;
     transition: background-color 0.2s ease;
   }
 
@@ -236,17 +251,37 @@
     background-color: var(--accent-error-hover);
   }
 
-  .log-time {
+  .log-col-time {
+    width: 8.5rem;
+    padding: 0.15rem 0.4rem;
     color: var(--text-dim);
-    flex-shrink: 0;
     font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .log-col-icon {
+    width: 1.5rem;
+    padding: 0.15rem 0;
+    text-align: center;
+  }
+
+  .log-col-context {
+    width: 10rem;
+    padding: 0.15rem 0.4rem;
+    white-space: nowrap;
+  }
+
+  .log-col-message {
+    padding: 0.15rem 0.4rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .log-level-icon {
     display: flex;
     align-items: center;
     justify-content: center;
-    flex-shrink: 0;
   }
 
   .log-entry.warn {
@@ -259,20 +294,12 @@
     color: var(--accent-error);
   }
 
-  .log-entry.warn .timestamp,
-  .log-entry.warn .log-context,
-  .log-entry.warn .log-level-icon,
-  .log-entry.warn .log-text,
-  .log-entry.error .timestamp,
-  .log-entry.error .log-context,
-  .log-entry.error .log-level-icon,
-  .log-entry.error .log-text {
+  .log-entry.warn td,
+  .log-entry.error td {
     color: inherit;
   }
 
   .log-text {
     color: var(--text-secondary);
-    white-space: nowrap;
-    flex: 1;
   }
 </style>

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -266,7 +266,7 @@
   }
 
   .log-col-context {
-    width: 12rem;
+    width: 10rem;
     padding: 0.15rem 0.4rem;
     white-space: nowrap;
   }

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { LogLevel } from '@domain/common/log';
-  import { ChevronUp, X, Check, TriangleAlert, List, type LucideProps } from '@lucide/svelte';
+  import { Check, ChevronUp, List, TriangleAlert, X, type LucideProps } from '@lucide/svelte';
   import { tooltip } from '@renderer/actions/tooltip';
   import { UI_TOKENS } from '@renderer/constants/design-system';
   import { IS_MAC } from '@renderer/infrastructure/adapters/platform-adapter';
@@ -252,7 +252,7 @@
   }
 
   .log-col-time {
-    width: 8.5rem;
+    width: 6.2rem;
     padding: 0.15rem 0.4rem;
     color: var(--text-dim);
     font-variant-numeric: tabular-nums;
@@ -260,13 +260,13 @@
   }
 
   .log-col-icon {
-    width: 1.5rem;
+    width: 1.2rem;
     padding: 0.15rem 0;
     text-align: center;
   }
 
   .log-col-context {
-    width: 10rem;
+    width: 8rem;
     padding: 0.15rem 0.4rem;
     white-space: nowrap;
   }

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -266,7 +266,7 @@
   }
 
   .log-col-context {
-    width: 8rem;
+    width: 12rem;
     padding: 0.15rem 0.4rem;
     white-space: nowrap;
   }

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -97,7 +97,7 @@
                   </div>
                 </td>
                 <td class="log-col-context">
-                  <span class="log-context" use:tooltip={log.context}>[{log.context}]</span>
+                  <span class="log-context">[{log.context}]</span>
                 </td>
                 <td class="log-col-message">
                   <span class="log-text" use:tooltip={log.message}>

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -252,7 +252,7 @@
   }
 
   .log-col-time {
-    width: 7.2rem;
+    width: 6.7rem;
     padding: 0.15rem 0.8rem 0.15rem 0.4rem;
     color: var(--text-dim);
     font-variant-numeric: tabular-nums;

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -266,13 +266,13 @@
   }
 
   .log-col-context {
-    width: 10rem;
-    padding: 0.15rem 0.4rem;
+    width: 9rem;
+    padding: 0.15rem 0.2rem;
     white-space: nowrap;
   }
 
   .log-col-message {
-    padding: 0.15rem 0.4rem;
+    padding: 0.15rem 0.2rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -252,8 +252,8 @@
   }
 
   .log-col-time {
-    width: 6.2rem;
-    padding: 0.15rem 0.4rem;
+    width: 7.2rem;
+    padding: 0.15rem 0.8rem 0.15rem 0.4rem;
     color: var(--text-dim);
     font-variant-numeric: tabular-nums;
     white-space: nowrap;

--- a/src/shared/ipc.test.ts
+++ b/src/shared/ipc.test.ts
@@ -7,10 +7,10 @@ describe('ipc shared constants', () => {
   });
 
   it('IPC_CHANNELS が正しく定義されていること', () => {
-    expect(IPC_CHANNELS.READ_METADATA).toBe('tag:read-metadata');
-    expect(IPC_CHANNELS.WRITE_METADATA).toBe('tag:write-metadata');
-    expect(IPC_CHANNELS.SELECT_DIRECTORY).toBe('app:select-directory');
-    expect(IPC_CHANNELS.SCAN_DIRECTORY).toBe('tag:scan-directory');
-    expect(IPC_CHANNELS.PICK_IMAGE).toBe('tag:pick-image');
+    expect(IPC_CHANNELS.READ_TAG).toBe('tag:read-tag');
+    expect(IPC_CHANNELS.WRITE_TAG).toBe('tag:write-tag');
+    expect(IPC_CHANNELS.SELECT_DIR).toBe('app:select-dir');
+    expect(IPC_CHANNELS.SCAN_DIR).toBe('tag:scan-dir');
+    expect(IPC_CHANNELS.PICK_IMG).toBe('tag:pick-img');
   });
 });

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1,6 +1,6 @@
 import type { LogHandler } from '@domain/common/log';
-import type { ScanResult, AppResult } from '@domain/flac/types';
 import type { FlacTrack, Picture } from '@domain/flac/models';
+import type { AppResult, ScanResult } from '@domain/flac/types';
 import type { Platform } from './platform';
 import type { AppSettings } from './settings';
 import type { Unsubscribe } from './types';
@@ -15,65 +15,58 @@ export const IMAGE_PROTOCOL_SCHEME = 'flac-image';
  */
 export const IPC_CHANNELS = {
   /** メタデータの読み取り */
-  READ_METADATA: 'tag:read-metadata',
+  READ_TAG: 'tag:read-tag',
   /** メタデータの書き込み */
-  WRITE_METADATA: 'tag:write-metadata',
+  WRITE_TAG: 'tag:write-tag',
   /** フォルダ選択ダイアログを表示 */
-  SELECT_DIRECTORY: 'app:select-directory',
+  SELECT_DIR: 'app:select-dir',
   /** ディレクトリ内のFLACファイルを探索 */
-  SCAN_DIRECTORY: 'tag:scan-directory',
+  SCAN_DIR: 'tag:scan-dir',
   /** 画像ファイルを選択して読み込み */
-  PICK_IMAGE: 'tag:pick-image',
+  PICK_IMG: 'tag:pick-img',
   /** 指定したパスの画像情報を取得 */
-  GET_IMAGE_INFO: 'tag:get-image-info',
+  IMG_INFO: 'tag:img-info',
   /** ファイルのリネーム */
-  RENAME_FILE: 'tag:rename-file',
+  RENAME: 'tag:rename',
   /** メタデータに基づいた新しいパスの生成 */
-  GENERATE_NEW_PATH: 'tag:generate-new-path',
+  GEN_PATH: 'tag:gen-path',
   /** ログメッセージの通知 */
-  ON_LOG_MESSAGE: 'app:on-log-message',
+  ON_LOG: 'app:on-log',
   /** 実行環境のプラットフォームを取得 */
-  GET_PLATFORM: 'app:get-platform',
+  PLATFORM: 'app:platform',
   /** アプリケーション設定の取得 */
-  GET_SETTINGS: 'app:get-settings',
+  GET_CONFIG: 'app:get-config',
   /** アプリケーション設定の更新 */
-  UPDATE_SETTINGS: 'app:update-settings',
+  UPDATE_CONFIG: 'app:update-config',
   /** メインウィンドウを表示 */
-  SHOW_MAIN_WINDOW: 'app:show-main-window'
+  SHOW_MAIN: 'app:show-main'
 } as const;
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];
 
 /**
- * プロジェクト全体の IPC 通信の「契約」を定義するインターフェース。
+ * IpcApi インターフェースの定義。
+ * メインプロセスとレンダラープロセスの間での型安全な通信を保証します。
  */
 export interface IpcApi {
-  /** 指定されたパスの FLAC メタデータを読み取ります */
-  readMetadata: (filePath: string) => Promise<AppResult<FlacTrack>>;
-  /** 指定されたパスの FLAC メタデータを書き込みます */
-  writeMetadata: (track: FlacTrack) => Promise<AppResult<string>>;
-  /** フォルダ選択ダイアログを表示し、選択されたパスを返します */
-  selectDirectory: () => Promise<string | null>;
-  /** 指定されたパス（ファイルまたはディレクトリ）内のFLACファイルのパスリストを返します */
-  scanDirectory: (targetPaths: string[]) => Promise<AppResult<ScanResult>>;
-  /** 画像ファイルを選択し、メタデータ用の Picture オブジェクトを返します */
-  pickImage: () => Promise<AppResult<Picture | null>>;
-  /** 指定したパスの画像ファイルから Picture オブジェクトを生成して返します */
-  getImageInfo: (filePath: string) => Promise<AppResult<Picture>>;
-  /** ファイルをリネーム（移動）します */
-  renameFile: (oldPath: string, newPath: string) => Promise<AppResult<void>>;
-  /** メタデータに基づいて新しいファイルパスを生成します */
-  generateNewPath: (track: FlacTrack) => Promise<AppResult<string>>;
-  /** File オブジェクトから OS 上のファイルシステムパスを取得します */
-  getPathForFile: (file: File) => string;
-  /** 実行環境のプラットフォームを取得します */
-  getPlatform: () => Promise<Platform>;
-  /** アプリケーション設定を取得します */
-  getSettings: () => Promise<AppResult<AppSettings>>;
-  /** アプリケーション設定を更新します */
-  updateSettings: (settings: Partial<AppSettings>) => Promise<AppResult<void>>;
-  /** メインウィンドウを表示します */
-  showMainWindow: () => Promise<void>;
-  /** ログメッセージを受信した時のコールバックを登録します */
-  onLogMessage: (callback: LogHandler) => Unsubscribe;
+  readMetadata(path: string): Promise<AppResult<FlacTrack>>;
+  writeMetadata(track: FlacTrack): Promise<AppResult<void>>;
+  selectDirectory(): Promise<string | undefined>;
+  scanDirectory(targetPaths: string[]): Promise<ScanResult>;
+  pickImage(): Promise<Picture | undefined>;
+  getImageInfo(path: string): Promise<Picture | undefined>;
+  renameFile(oldPath: string, newPath: string): Promise<AppResult<void>>;
+  generateNewPath(track: FlacTrack): Promise<string>;
+  getPathForFile(file: File): string;
+  getPlatform(): Promise<Platform>;
+  getSettings(): Promise<AppResult<AppSettings>>;
+  updateSettings(settings: Partial<AppSettings>): Promise<AppResult<void>>;
+  showMainWindow(): Promise<void>;
+  onLogMessage(callback: LogHandler): Unsubscribe;
+}
+
+declare global {
+  interface Window {
+    api: IpcApi;
+  }
 }


### PR DESCRIPTION
GitHub issue #159 の対応です。ログ表示の整列と、IPCチャネル名のリファクタリングを行いました。

### 変更内容
1. **ログ表示の整形 (`StatusBar.svelte`)**:
   - `table` タグ（`table-layout: fixed`）を使用し、タイムスタンプ、レベルアイコン、コンテキスト、メッセージの各列を厳密に整列させました。
   - タイムスタンプ列の幅を `7.2rem` に広げ、右側に適切なパディング（`0.8rem`）を確保しました。
   - コンテキスト列の不要なツールチップを削除し、表示をクリーンにしました。
2. **IPCチャネルのリファクタリング (`shared/ipc.ts`)**:
   - チャネル名（値）と定数名（キー）の両方を短縮し、一貫性のあるシンプルな命名に変更しました。
     - 例: `READ_METADATA` -> `READ_TAG` (`tag:read-tag`)
     - 例: `GENERATE_NEW_PATH` -> `GEN_PATH` (`tag:gen-path`)
   - メインプロセス、プリロード（API露出部）、テストコードのすべての参照箇所を一括で更新しました。
3. **その他**:
   - `src/shared/ipc.test.ts` の期待値を新しい命名に合わせて更新しました。
   - バージョンは `1.2.1` を維持しています。

### 検証内容
- `pnpm lint`: PASS
- `pnpm test`: PASS (IPC定数のテストを含む)
- `pnpm build`: PASS
- 手動によるレイアウト確認（テーブル構造による整列の保証）
