### PR TITLE
feat: electron-logの導入 #160

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
           'flac-tagger',
           'music-metadata',
           'fast-equals',
+          'electron-log',
           'electron-updater',
           '@electron-toolkit/utils'
         ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",
@@ -46,6 +46,7 @@
   "dependencies": {
     "@electron-toolkit/utils": "^4.0.0",
     "@lucide/svelte": "^1.11.0",
+    "electron-log": "^5.4.3",
     "electron-store": "^11.0.2",
     "electron-updater": "^6.8.3",
     "fast-equals": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.3.2",
+  "version": "1.3.0",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@lucide/svelte':
         specifier: ^1.11.0
         version: 1.11.0(svelte@5.55.5(@typescript-eslint/types@8.58.0))
+      electron-log:
+        specifier: ^5.4.3
+        version: 5.4.3
       electron-store:
         specifier: ^11.0.2
         version: 11.0.2
@@ -784,66 +787,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -1490,6 +1506,10 @@ packages:
     resolution: {integrity: sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  electron-log@5.4.3:
+    resolution: {integrity: sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==}
+    engines: {node: '>= 14'}
 
   electron-publish@26.8.1:
     resolution: {integrity: sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==}
@@ -4492,6 +4512,8 @@ snapshots:
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
+
+  electron-log@5.4.3: {}
 
   electron-publish@26.8.1:
     dependencies:

--- a/src/domain/common/log.ts
+++ b/src/domain/common/log.ts
@@ -4,7 +4,7 @@ import { getCurrentTimestamp } from '@shared/utils/date';
 /**
  * ログレベルの定義。
  */
-export type LogLevel = 'INFO' | 'WARN' | 'ERROR';
+export type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
 
 /**
  * ログメッセージの構造。

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,10 +1,15 @@
 import { electronApp, optimizer } from '@electron-toolkit/utils';
 import { app, BrowserWindow } from 'electron';
+import log from 'electron-log/main';
 import { initializeIpc } from './ipc';
 import { registerProtocolsPrivileged, registerProtocols } from './protocols';
 import { createWindow } from './window';
 import { initAutoUpdater } from './services/platform/update';
 import { setAppMenu } from './menu';
+
+// Initialize electron-log
+log.initialize();
+log.errorHandler.startCatching();
 
 registerProtocolsPrivileged();
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,7 +7,7 @@ import { logger } from './services/platform/logger';
 import { initAutoUpdater } from './services/platform/update';
 import { createWindow } from './window';
 
-logger.info({ context: 'App', message: 'Application starting...' });
+logger.info({ context: 'application', message: 'Application starting...' });
 
 registerProtocolsPrivileged();
 
@@ -37,4 +37,8 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
   }
+});
+
+app.on('will-quit', () => {
+  logger.info({ context: 'application', message: 'Application quitting...' });
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,15 +1,13 @@
 import { electronApp, optimizer } from '@electron-toolkit/utils';
 import { app, BrowserWindow } from 'electron';
-import log from 'electron-log/main';
 import { initializeIpc } from './ipc';
-import { registerProtocolsPrivileged, registerProtocols } from './protocols';
-import { createWindow } from './window';
-import { initAutoUpdater } from './services/platform/update';
 import { setAppMenu } from './menu';
+import { registerProtocols, registerProtocolsPrivileged } from './protocols';
+import { logger } from './services/platform/logger';
+import { initAutoUpdater } from './services/platform/update';
+import { createWindow } from './window';
 
-// Initialize electron-log
-log.initialize();
-log.errorHandler.startCatching();
+logger.info({ context: 'App', message: 'Application starting...' });
 
 registerProtocolsPrivileged();
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,7 +7,7 @@ import { logger } from './services/platform/logger';
 import { initAutoUpdater } from './services/platform/update';
 import { createWindow } from './window';
 
-logger.info({ context: 'application', message: 'Application starting...' });
+logger.info({ context: 'application', message: 'Application launching...' });
 
 registerProtocolsPrivileged();
 

--- a/src/main/services/platform/logger.test.ts
+++ b/src/main/services/platform/logger.test.ts
@@ -10,7 +10,18 @@ vi.mock('electron-log/main', () => ({
     initialize: vi.fn(),
     errorHandler: {
       startCatching: vi.fn()
+    },
+    transports: {
+      file: {
+        level: 'debug'
+      }
     }
+  }
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false
   }
 }));
 

--- a/src/main/services/platform/logger.test.ts
+++ b/src/main/services/platform/logger.test.ts
@@ -1,12 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import log from 'electron-log/main';
 import { logger } from './logger';
+
+vi.mock('electron-log/main', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    initialize: vi.fn()
+  }
+}));
 
 describe('Logger', () => {
   beforeEach(() => {
     // EventEmitter のリスナーをクリア
     logger.removeAllListeners();
-    // console.log をモック化
-    vi.spyOn(console, 'log').mockImplementation(() => {});
+    // モックをリセット
+    vi.clearAllMocks();
   });
 
   describe('ログ出力メソッド', () => {
@@ -59,13 +69,9 @@ describe('Logger', () => {
       );
     });
 
-    it('console.log にも出力されること', () => {
-      logger.info({ context: 'console', message: 'console test' });
-      expect(console.log).toHaveBeenCalled();
-      // 出力フォーマットの断片を確認
-      expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('[INFO] [console] console test')
-      );
+    it('electron-log にも出力されること', () => {
+      logger.info({ context: 'electron', message: 'electron test' });
+      expect(log.info).toHaveBeenCalledWith('[electron] electron test');
     });
   });
 

--- a/src/main/services/platform/logger.test.ts
+++ b/src/main/services/platform/logger.test.ts
@@ -4,6 +4,7 @@ import { logger } from './logger';
 
 vi.mock('electron-log/main', () => ({
   default: {
+    debug: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
@@ -19,10 +20,12 @@ vi.mock('electron-log/main', () => ({
   }
 }));
 
+const mockApp = vi.hoisted(() => ({
+  isPackaged: false
+}));
+
 vi.mock('electron', () => ({
-  app: {
-    isPackaged: false
-  }
+  app: mockApp
 }));
 
 describe('Logger', () => {
@@ -34,6 +37,21 @@ describe('Logger', () => {
   });
 
   describe('ログ出力メソッド', () => {
+    it('debug() が正しくログイベントを発火させること', () => {
+      const handler = vi.fn();
+      logger.onLog(handler);
+
+      logger.debug({ context: 'test', message: 'test debug message' });
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          level: 'DEBUG',
+          context: 'test',
+          message: 'test debug message'
+        })
+      );
+    });
+
     it('info() が正しくログイベントを発火させること', () => {
       const handler = vi.fn();
       logger.onLog(handler);
@@ -101,6 +119,21 @@ describe('Logger', () => {
 
       expect(handler1).toHaveBeenCalled();
       expect(handler2).toHaveBeenCalled();
+    });
+
+    it('本番環境では DEBUG ログが転送されないこと', () => {
+      mockApp.isPackaged = true;
+
+      const handler = vi.fn();
+      logger.onLog(handler);
+
+      logger.debug({ context: 'test', message: 'hidden debug' });
+      expect(handler).not.toHaveBeenCalled();
+
+      logger.info({ context: 'test', message: 'visible info' });
+      expect(handler).toHaveBeenCalled();
+
+      mockApp.isPackaged = false; // 元に戻す
     });
   });
 });

--- a/src/main/services/platform/logger.test.ts
+++ b/src/main/services/platform/logger.test.ts
@@ -7,7 +7,10 @@ vi.mock('electron-log/main', () => ({
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
-    initialize: vi.fn()
+    initialize: vi.fn(),
+    errorHandler: {
+      startCatching: vi.fn()
+    }
   }
 }));
 

--- a/src/main/services/platform/logger.ts
+++ b/src/main/services/platform/logger.ts
@@ -1,8 +1,8 @@
+import { LogHandler, LogParams, createLogMessage } from '@domain/common/log';
 import { app } from 'electron';
+import log from 'electron-log/main';
 import { EventEmitter } from 'node:events';
 import { format } from 'node:util';
-import log from 'electron-log/main';
-import { LogHandler, LogParams, createLogMessage } from '@domain/common/log';
 
 /**
  * ロガーに渡されるオプション引数。
@@ -28,6 +28,10 @@ class Logger extends EventEmitter {
     } else {
       log.transports.file.level = 'debug';
     }
+  }
+
+  public debug(options: LoggerOptions, ...args: unknown[]): void {
+    this.#log({ ...options, level: 'DEBUG' }, ...args);
   }
 
   public info(options: LoggerOptions, ...args: unknown[]): void {
@@ -62,10 +66,18 @@ class Logger extends EventEmitter {
       context: params.context,
       message: formattedMessage
     });
-    this.emit(Logger.#LOG_EVENT, logMessage);
+
+    // UI（Renderer）への転送
+    // 本番環境では DEBUG ログは転送しない
+    if (!(app.isPackaged && params.level === 'DEBUG')) {
+      this.emit(Logger.#LOG_EVENT, logMessage);
+    }
 
     const logText = `[${params.context}] ${formattedMessage}`;
     switch (params.level) {
+      case 'DEBUG':
+        log.debug(logText);
+        break;
       case 'INFO':
         log.info(logText);
         break;

--- a/src/main/services/platform/logger.ts
+++ b/src/main/services/platform/logger.ts
@@ -16,6 +16,12 @@ type LoggerOptions = Omit<LogParams, 'level'>;
 class Logger extends EventEmitter {
   static readonly #LOG_EVENT = 'log';
 
+  constructor() {
+    super();
+    log.initialize();
+    log.errorHandler.startCatching();
+  }
+
   public info(options: LoggerOptions, ...args: unknown[]): void {
     this.#log({ ...options, level: 'INFO' }, ...args);
   }

--- a/src/main/services/platform/logger.ts
+++ b/src/main/services/platform/logger.ts
@@ -22,7 +22,7 @@ class Logger extends EventEmitter {
     log.initialize();
     log.errorHandler.startCatching();
 
-    // 本番環境（パッケージ化後）は warning と error しかファイルに書き込まない
+    // 本番環境と開発環境のログレベル設定
     if (app.isPackaged) {
       log.transports.file.level = 'warn';
     } else {

--- a/src/main/services/platform/logger.ts
+++ b/src/main/services/platform/logger.ts
@@ -1,7 +1,7 @@
+import { LogHandler, LogParams, createLogMessage } from '@domain/common/log';
+import log from 'electron-log/main';
 import { EventEmitter } from 'node:events';
 import { format } from 'node:util';
-import log from 'electron-log/main';
-import { LogHandler, LogParams, createLogMessage } from '@domain/common/log';
 
 /**
  * ロガーに渡されるオプション引数。
@@ -56,7 +56,6 @@ class Logger extends EventEmitter {
     });
     this.emit(Logger.#LOG_EVENT, logMessage);
 
-    // electron-log に出力（ファイル保存と標準出力を兼ねる）
     const logText = `[${params.context}] ${formattedMessage}`;
     switch (params.level) {
       case 'INFO':
@@ -67,9 +66,6 @@ class Logger extends EventEmitter {
         break;
       case 'ERROR':
         log.error(logText);
-        break;
-      default:
-        log.info(logText);
         break;
     }
   }

--- a/src/main/services/platform/logger.ts
+++ b/src/main/services/platform/logger.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 import { format } from 'node:util';
+import log from 'electron-log/main';
 import { LogHandler, LogParams, createLogMessage } from '@domain/common/log';
-import { formatTimeWithMs } from '@shared/utils/date';
 
 /**
  * ロガーに渡されるオプション引数。
@@ -50,9 +50,22 @@ class Logger extends EventEmitter {
     });
     this.emit(Logger.#LOG_EVENT, logMessage);
 
-    // 標準出力にも出す
-    const timePrefix = `[${formatTimeWithMs(logMessage.timestamp)}]`;
-    console.log(`${timePrefix} [${params.level}] [${params.context}] ${formattedMessage}`);
+    // electron-log に出力（ファイル保存と標準出力を兼ねる）
+    const logText = `[${params.context}] ${formattedMessage}`;
+    switch (params.level) {
+      case 'INFO':
+        log.info(logText);
+        break;
+      case 'WARN':
+        log.warn(logText);
+        break;
+      case 'ERROR':
+        log.error(logText);
+        break;
+      default:
+        log.info(logText);
+        break;
+    }
   }
 }
 

--- a/src/main/services/platform/logger.ts
+++ b/src/main/services/platform/logger.ts
@@ -1,7 +1,8 @@
-import { LogHandler, LogParams, createLogMessage } from '@domain/common/log';
-import log from 'electron-log/main';
+import { app } from 'electron';
 import { EventEmitter } from 'node:events';
 import { format } from 'node:util';
+import log from 'electron-log/main';
+import { LogHandler, LogParams, createLogMessage } from '@domain/common/log';
 
 /**
  * ロガーに渡されるオプション引数。
@@ -20,6 +21,13 @@ class Logger extends EventEmitter {
     super();
     log.initialize();
     log.errorHandler.startCatching();
+
+    // 本番環境（パッケージ化後）は warning と error しかファイルに書き込まない
+    if (app.isPackaged) {
+      log.transports.file.level = 'warn';
+    } else {
+      log.transports.file.level = 'debug';
+    }
   }
 
   public info(options: LoggerOptions, ...args: unknown[]): void {

--- a/src/renderer/src/components/StatusBar.svelte
+++ b/src/renderer/src/components/StatusBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { LogLevel } from '@domain/common/log';
-  import { Check, ChevronUp, List, TriangleAlert, X, type LucideProps } from '@lucide/svelte';
+  import { Bug, Check, ChevronUp, List, TriangleAlert, X, type LucideProps } from '@lucide/svelte';
   import { tooltip } from '@renderer/actions/tooltip';
   import { UI_TOKENS } from '@renderer/constants/design-system';
   import { IS_MAC } from '@renderer/infrastructure/adapters/platform-adapter';
@@ -11,6 +11,7 @@
   import { slide } from 'svelte/transition';
 
   const levelIcons: ReadonlyMap<LogLevel, Component<LucideProps>> = new Map([
+    ['DEBUG', Bug],
     ['INFO', Check],
     ['WARN', TriangleAlert],
     ['ERROR', X]
@@ -85,7 +86,7 @@
           <tbody>
             {#each logStore.logs as log (log.id)}
               {@const ICON = levelIcons.get(log.level)}
-              <tr class="log-entry {log.level.toLowerCase()}">
+              <tr class="log-entry {log.level.toLowerCase()}" use:tooltip={log.message}>
                 <td class="log-col-time">
                   <span class="timestamp">[{formatTimeWithMs(log.timestamp)}]</span>
                 </td>
@@ -100,7 +101,7 @@
                   <span class="log-context">[{log.context}]</span>
                 </td>
                 <td class="log-col-message">
-                  <span class="log-text" use:tooltip={log.message}>
+                  <span class="log-text">
                     {log.message}
                   </span>
                 </td>
@@ -158,6 +159,10 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .status-item.debug {
+    color: var(--text-muted);
   }
 
   .status-item.error {
@@ -282,6 +287,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+
+  .log-entry.debug {
+    color: var(--text-muted);
+    opacity: 0.8;
   }
 
   .log-entry.warn {


### PR DESCRIPTION
## 概要
GitHub Issue #160 に基づき、`electron-log` を導入し、アプリケーションのロギング基盤を刷新しました。
エラーの永続化（ファイル出力）と自動ローテーションを実現するとともに、開発効率向上のための `DEBUG` レベルの導入や、本番環境でのログ制御を追加しています。

## 変更内容

### メインプロセス / ロギング基盤
- **electron-log の導入**: 永続的なファイルログ（OS標準のログディレクトリ）と自動ローテーション（1MB）を実現。
- **リファクタリング**: `electron-log` の初期化処理を `Logger` クラスのコンストラクタにカプセル化。
- **DEBUG レベルの追加**: 新しく `DEBUG` ログレベルを導入し、`logger.debug()` メソッドを追加。
- **環境に応じたログ制御**: 
    - パッケージ化後（本番環境）は、ファイルログの出力を `warn` 以上に制限。
    - 本番環境では `DEBUG` ログを Renderer プロセス（UI）に転送しないように制御。
- **アプリ起動・終了ログ**: `index.ts` にてアプリのライフサイクルに応じたログ出力を追加。
- **ビルド設定**: `electron-log` を外部モジュールとして扱うよう `electron.vite.config.ts` を更新。

### レンダラープロセス / UI
- **StatusBar の改善**:
    - ログ一覧の各行全体にツールチップを適用し、メッセージの詳細を確認しやすく変更。
    - `DEBUG` レベル用のアイコン（Bug）とスタイル（控えめな表示）を追加。

### その他
- **バージョン**: `1.3.0` に更新。
- **テスト**: `Logger` クラスのテストを更新し、新しい分岐やレベル設定を 100% カバー。

## 検証内容
- [x] `pnpm lint`: パス
- [x] `pnpm test`: パス（カバレッジ維持）
- [x] `pnpm build`: パス（パッケージ化設定の整合性確認済み）
