### PR TITLE
fix: release.ymlの判定ロジック修正とテストエラーの解消 #166

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ steps.get_version.outputs.tag }}"
-          if gh api "repos/${{ github.repository }}/releases/tags/$TAG" >/dev/null 2>&1; then
+          echo "Checking release existence for $TAG..."
+          if gh release view "$TAG" >/dev/null 2>&1; then
             echo "should_release=false" >> $GITHUB_OUTPUT
             echo "Release $TAG already exists. Skipping build."
           else

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/main/infrastructure/logging/result-logging.test.ts
+++ b/src/main/infrastructure/logging/result-logging.test.ts
@@ -1,7 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { failure, success } from '@domain/common/result';
+
+vi.mock('electron-log/main', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    initialize: vi.fn(),
+    errorHandler: {
+      startCatching: vi.fn()
+    },
+    transports: {
+      file: {
+        level: 'debug'
+      }
+    }
+  }
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false
+  }
+}));
+
 import { logger } from '@services/platform/logger';
 import * as formatter from '@domain/flac/app-error-formatter';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { withResultLogging } from './result-logging';
 
 describe('result-logging', () => {


### PR DESCRIPTION
GitHub Issue #166 の対応を行いました。

### 変更内容
1. **`.github/workflows/release.yml` の修正**
   - リリースの存在確認に使用していた `gh api` コマンドを、より信頼性の高い `gh release view` に変更しました。
   - `gh api` ではドラフトリリースや特定の条件下で正しく判定されない可能性があるため、標準的な `gh release view` を使用するようにしました。
   - デバッグを容易にするため、確認対象のタグ名をログに出力する処理を追加しました。

2. **`package.json` のバージョン更新**
   - ワークフローのルールに基づき、バージョンを `1.3.1` に更新しました。

3. **`result-logging.test.ts` の修正**
   - テスト環境で Electron の `app` モジュールが正しくモックされておらず、`Logger` のコンストラクタで失敗していた問題を修正しました。

### 検証内容
- `pnpm format`: PASS
- `pnpm lint`: PASS
- `pnpm test`: PASS (全242テスト通過)

ご確認をお願いします。