### PR TITLE
fix: デバッグ環境（ソースマップ、デバッグポート）の復旧と最適化

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,6 @@
       "screenResolution": "1600x1000"
     }
   },
-  "forwardPorts": [5901, 6080],
+  "forwardPorts": [5901, 6080, 9222],
   "postCreateCommand": "pnpm install"
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,23 +2,37 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "デバッグ",
+      // アプリ本体（Node.js側）を起動してデバッグ
+      "name": "メイン",
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}",
       "runtimeExecutable": "${workspaceFolder}/node_modules/electron/dist/electron",
-      "runtimeArgs": ["--no-sandbox", "--disable-gpu"],
+      "runtimeArgs": ["--remote-debugging-port=9222", "--no-sandbox", "--disable-gpu"],
       "args": ["${workspaceFolder}/out/main/index.js"],
       "outputCapture": "std",
       "console": "integratedTerminal",
       "preLaunchTask": "pnpm: build",
       "sourceMaps": true,
       "smartStep": true,
-      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "outFiles": ["${workspaceFolder}/out/**/*.js", "${workspaceFolder}/out/**/*.mjs"],
       "env": {
         "DISPLAY": ":1",
         "ELECTRON_DISABLE_SANDBOX": "1"
       }
+    },
+    {
+      // 起動したアプリの画面側にアタッチしてデバッグ。
+      // 必ず先にメインプロセスを起動し、ウィンドウが表示された後に開始すること。
+      "name": "レンダラー",
+      "type": "chrome",
+      "request": "attach",
+      "port": 9222,
+      "address": "127.0.0.1",
+      "webRoot": "${workspaceFolder}",
+      "sourceMaps": true,
+      "timeout": 60000,
+      "urlFilter": "file:///**/index.html*"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "pnpm: build",
       "type": "shell",
-      "command": "pnpm build",
+      "command": "DEBUG=true pnpm build",
       "group": "build",
       "problemMatcher": "$tsc"
     }

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -2,51 +2,62 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'electron-vite';
 import { resolve } from 'path';
 
-export default defineConfig({
-  main: {
-    build: {
-      externalizeDeps: {
-        exclude: [
-          'flac-tagger',
-          'music-metadata',
-          'fast-equals',
-          'electron-log',
-          'electron-updater',
-          '@electron-toolkit/utils'
-        ]
+export default defineConfig(() => {
+  const isDebug = process.env.DEBUG === 'true' || process.env.NODE_ENV === 'development';
+
+  return {
+    main: {
+      build: {
+        sourcemap: isDebug,
+        externalizeDeps: {
+          exclude: [
+            'flac-tagger',
+            'music-metadata',
+            'fast-equals',
+            'electron-log',
+            'electron-updater',
+            '@electron-toolkit/utils'
+          ]
+        }
+      },
+      resolve: {
+        alias: {
+          '@shared': resolve('src/shared'),
+          '@domain': resolve('src/domain'),
+          '@services': resolve('src/main/services'),
+          '@main': resolve('src/main'),
+          '@resources': resolve('resources'),
+          '@root': resolve('.')
+        }
       }
     },
-    resolve: {
-      alias: {
-        '@shared': resolve('src/shared'),
-        '@domain': resolve('src/domain'),
-        '@services': resolve('src/main/services'),
-        '@main': resolve('src/main'),
-        '@resources': resolve('resources'),
-        '@root': resolve('.')
-      }
-    }
-  },
-  preload: {
-    resolve: {
-      alias: {
-        '@shared': resolve('src/shared'),
-        '@domain': resolve('src/domain'),
-        '@resources': resolve('resources'),
-        '@root': resolve('.')
-      }
-    }
-  },
-  renderer: {
-    resolve: {
-      alias: {
-        '@renderer': resolve('src/renderer/src'),
-        '@shared': resolve('src/shared'),
-        '@domain': resolve('src/domain'),
-        '@resources': resolve('resources'),
-        '@root': resolve('.')
+    preload: {
+      build: {
+        sourcemap: isDebug
+      },
+      resolve: {
+        alias: {
+          '@shared': resolve('src/shared'),
+          '@domain': resolve('src/domain'),
+          '@resources': resolve('resources'),
+          '@root': resolve('.')
+        }
       }
     },
-    plugins: [svelte()]
-  }
+    renderer: {
+      build: {
+        sourcemap: isDebug
+      },
+      resolve: {
+        alias: {
+          '@renderer': resolve('src/renderer/src'),
+          '@shared': resolve('src/shared'),
+          '@domain': resolve('src/domain'),
+          '@resources': resolve('resources'),
+          '@root': resolve('.')
+        }
+      },
+      plugins: [svelte()]
+    }
+  };
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.4.4",
+  "version": "1.4.3",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",


### PR DESCRIPTION
## 概要
VS Code のデバッガーでブレークポイントが機能しなくなっていた問題を解決し、開発環境を最適化しました。

## 変更内容
- **electron.vite.config.ts**: 
  - `DEBUG=true` または `NODE_ENV=development` の時のみソースマップを出力するように変更。リリース用ビルドの軽量化とデバッグの容易性を両立させました。
- **.vscode/launch.json**:
  - 設定名を日本語（メイン、レンダラー）に変更し、直感的に操作できるようにしました。
  - デバッグの正しい順序（メイン起動 → ウィンドウ表示 → レンダラー接続）をコメントとして追記しました。
  - `sourceMapPathOverrides` なしでも動作するように設定を整理しました。
- **.vscode/tasks.json**:
  - デバッグ用のビルドタスクに `DEBUG=true` を付与し、条件付きソースマップ出力をトリガーするようにしました。
- **.devcontainer/devcontainer.json**:
  - Electron のリモートデバッグポート `9222` を `forwardPorts` に追加し、Dev Container 環境下でのアタッチを可能にしました。
- **package.json**:
  - バージョンを `1.4.4` に更新しました。

## 検証内容
- [x] メインプロセスでブレークポイントがヒットすることを確認
- [x] レンダラープロセスでブレークポイントがヒットすることを確認
- [x] `pnpm build`（通常ビルド）でソースマップが出力されないことを確認
- [x] `pnpm lint` / `pnpm format` パス
