### PR TITLE
feat: デバッグログの強化と整理 (#179)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.4.6",
+  "version": "1.5.0",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/main/infrastructure/logging/logger.ts
+++ b/src/main/infrastructure/logging/logger.ts
@@ -24,6 +24,11 @@ class Logger extends EventEmitter {
 
     // 保存されている設定、または環境（開発/本番）に基づいてログレベルを初期化
     this.updateLogLevel();
+
+    // 設定変更を購読し、動的に反映する
+    settingsRepository.onChange(() => {
+      this.updateLogLevel();
+    });
   }
 
   /**

--- a/src/main/infrastructure/logging/logger.ts
+++ b/src/main/infrastructure/logging/logger.ts
@@ -1,8 +1,8 @@
 import { LogHandler, LogParams, createLogMessage } from '@domain/common/log';
-import { app } from 'electron';
 import log from 'electron-log/main';
 import { EventEmitter } from 'node:events';
 import { format } from 'node:util';
+import { settingsRepository } from '@main/infrastructure/repositories/settings/settings-repository';
 
 /**
  * ロガーに渡されるオプション引数。
@@ -22,12 +22,21 @@ class Logger extends EventEmitter {
     log.initialize();
     log.errorHandler.startCatching();
 
-    // 本番環境と開発環境のログレベル設定
-    if (app.isPackaged) {
-      log.transports.file.level = 'warn';
-    } else {
-      log.transports.file.level = 'debug';
-    }
+    // 保存されている設定、または環境（開発/本番）に基づいてログレベルを初期化
+    this.updateLogLevel();
+  }
+
+  /**
+   * 現在の設定に基づいてログレベル（ファイル出力および UI 転送）を更新します。
+   */
+  public updateLogLevel(): void {
+    const level = settingsRepository.settings.logLevel;
+
+    // ファイル出力およびコンソール出力レベルの設定
+    // 開発・本番に関わらず、ユーザー設定に従う
+    const logTaggerLevel = level === 'DEBUG' ? 'debug' : 'info';
+    log.transports.file.level = logTaggerLevel;
+    log.transports.console.level = logTaggerLevel;
   }
 
   public debug(options: LoggerOptions, ...args: unknown[]): void {
@@ -68,8 +77,9 @@ class Logger extends EventEmitter {
     });
 
     // UI（Renderer）への転送
-    // 本番環境では DEBUG ログは転送しない
-    if (!(app.isPackaged && params.level === 'DEBUG')) {
+    // 設定が INFO の場合は DEBUG ログを抑制する
+    const currentLevel = settingsRepository.settings.logLevel;
+    if (!(currentLevel === 'INFO' && params.level === 'DEBUG')) {
       this.emit(Logger.#LOG_EVENT, logMessage);
     }
 

--- a/src/main/infrastructure/repositories/flac/flac-read-repository.ts
+++ b/src/main/infrastructure/repositories/flac/flac-read-repository.ts
@@ -1,3 +1,4 @@
+import { logger } from '@main/infrastructure/logging/logger';
 import {
   IGNORE_TAG_KEYS,
   RawFlacData,
@@ -7,12 +8,15 @@ import {
 import { computeMd5 } from '@main/utils/crypto';
 import * as musicMetadata from 'music-metadata';
 
+const LOG_CONTEXT = 'FlacReadRepo';
+
 /**
  * 指定されたパスのFLACファイルから生のメタデータを読み取ります。
  */
 export const readRawFlacData = async (filePath: string): Promise<RawFlacData> => {
   const mmData = await musicMetadata.parseFile(filePath);
 
+  logger.debug({ context: LOG_CONTEXT, message: `Parsing completed: ${filePath}` });
   return {
     path: filePath,
     tags: mapLibTagsToRaw(mmData.native.vorbis || []),

--- a/src/main/infrastructure/repositories/settings/settings-repository.ts
+++ b/src/main/infrastructure/repositories/settings/settings-repository.ts
@@ -13,6 +13,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   renamePattern: `${TAG_PLACEHOLDERS.TRACK_NUMBER} - ${TAG_PLACEHOLDERS.TITLE}`,
   trackNumberPadding: 2,
   theme: 'system',
+  logLevel: 'INFO',
   genres: [
     'Pop',
     'Soundtrack',

--- a/src/main/infrastructure/repositories/settings/settings-repository.ts
+++ b/src/main/infrastructure/repositories/settings/settings-repository.ts
@@ -1,7 +1,7 @@
 import { TAG_PLACEHOLDERS } from '@domain/audio/constants';
-
 import type { AppSettings } from '@shared/settings';
 import Store from 'electron-store';
+import { EventEmitter } from 'node:events';
 
 const SETTINGS_FILE_NAME = 'tagutil-settings';
 
@@ -30,11 +30,14 @@ export const DEFAULT_SETTINGS: AppSettings = {
 
 /**
  * electron-store を使用してアプリケーション設定を永続化・管理するリポジトリ。
+ * 設定の変更を通知するための EventEmitter を継承しています。
  */
-export class SettingsRepository {
+export class SettingsRepository extends EventEmitter {
+  static readonly #CHANGED_EVENT = 'changed';
   #store: Store<AppSettings>;
 
   constructor() {
+    super();
     this.#store = new Store<AppSettings>({
       name: SETTINGS_FILE_NAME,
       defaults: DEFAULT_SETTINGS,
@@ -50,16 +53,30 @@ export class SettingsRepository {
   }
 
   /**
-   * 設定を更新します。
+   * 設定を更新し、変更イベントを発行します。
    * @param settings 更新する設定項目（部分更新）
    */
   updateSettings(settings: Partial<AppSettings>): void {
+    let changed = false;
     for (const [key, value] of Object.entries(settings)) {
       if (value === undefined || value === null) {
         continue;
       }
       this.#store.set(key, value);
+      changed = true;
     }
+
+    if (changed) {
+      this.emit(SettingsRepository.#CHANGED_EVENT, this.settings);
+    }
+  }
+
+  /**
+   * 設定変更のリスナーを登録します。
+   * @param handler 変更後の設定を受け取るハンドラ
+   */
+  onChange(handler: (settings: AppSettings) => void): void {
+    this.on(SettingsRepository.#CHANGED_EVENT, handler);
   }
 }
 

--- a/src/main/ipc/settings-handlers.ts
+++ b/src/main/ipc/settings-handlers.ts
@@ -4,7 +4,6 @@ import { settingsRepository } from '@main/infrastructure/repositories/settings/s
 import type { AppSettings } from '@shared/settings';
 import { success } from '@domain/common/result';
 import { withResultLogging } from '@main/infrastructure/logging/result-logging';
-import { logger } from '@main/infrastructure/logging/logger';
 
 /**
  * 設定に関連する IPC ハンドラを登録します。
@@ -19,7 +18,6 @@ export const registerSettingsHandlers = (): void => {
   ipcMain.handle(IPC_CHANNELS.UPDATE_CONFIG, async (_, settings: Partial<AppSettings>) => {
     return withResultLogging(IPC_CHANNELS.UPDATE_CONFIG, async () => {
       settingsRepository.updateSettings(settings);
-      logger.updateLogLevel();
       return success(undefined);
     });
   });

--- a/src/main/ipc/settings-handlers.ts
+++ b/src/main/ipc/settings-handlers.ts
@@ -4,6 +4,7 @@ import { settingsRepository } from '@main/infrastructure/repositories/settings/s
 import type { AppSettings } from '@shared/settings';
 import { success } from '@domain/common/result';
 import { withResultLogging } from '@main/infrastructure/logging/result-logging';
+import { logger } from '@main/infrastructure/logging/logger';
 
 /**
  * 設定に関連する IPC ハンドラを登録します。
@@ -18,6 +19,7 @@ export const registerSettingsHandlers = (): void => {
   ipcMain.handle(IPC_CHANNELS.UPDATE_CONFIG, async (_, settings: Partial<AppSettings>) => {
     return withResultLogging(IPC_CHANNELS.UPDATE_CONFIG, async () => {
       settingsRepository.updateSettings(settings);
+      logger.updateLogLevel();
       return success(undefined);
     });
   });

--- a/src/main/services/flac/image.ts
+++ b/src/main/services/flac/image.ts
@@ -1,11 +1,13 @@
+import { Picture } from '@domain/audio/models';
 import { success } from '@domain/common/result';
 import { AppResult } from '@domain/types';
-import { Picture } from '@domain/audio/models';
-
-import { readFileWithHash } from '@main/infrastructure/repositories/file/file-read-repository';
-import { getMimeTypeFromPath } from '@main/utils/mime';
+import { logger } from '@main/infrastructure/logging/logger';
 import { pickImageFile } from '@main/infrastructure/platform/dialog';
+import { readFileWithHash } from '@main/infrastructure/repositories/file/file-read-repository';
 import { readRawFlacData } from '@main/infrastructure/repositories/flac/flac-read-repository';
+import { getMimeTypeFromPath } from '@main/utils/mime';
+
+const LOG_CONTEXT = 'FlacImage';
 
 /**
  * FLAC ファイルから埋め込まれた画像を抽出します。
@@ -17,9 +19,14 @@ export const extractEmbeddedImage = async (
   const picture = pictures[0];
 
   if (!picture) {
+    logger.debug({ context: LOG_CONTEXT, message: `No image found in: ${filePath}` });
     return null;
   }
 
+  logger.debug({
+    context: LOG_CONTEXT,
+    message: `Image extracted: ${filePath} (${picture.mime})`
+  });
   return {
     buffer: picture.buffer,
     mime: picture.mime || 'image/jpeg'
@@ -44,11 +51,14 @@ export const getImageInfo = async (filePath: string): Promise<AppResult<Picture>
  * @returns 選択された画像のパス情報。キャンセルされた場合は Result(null)。
  */
 export const pickImage = async (): Promise<AppResult<Picture | null>> => {
+  logger.debug({ context: LOG_CONTEXT, message: 'Opening image picker dialog' });
   const filePath = await pickImageFile();
 
   if (!filePath) {
+    logger.debug({ context: LOG_CONTEXT, message: 'Image picker cancelled' });
     return success(null);
   }
 
+  logger.debug({ context: LOG_CONTEXT, message: `Image selected: ${filePath}` });
   return await getImageInfo(filePath);
 };

--- a/src/main/services/flac/mappers/flac-write-mapper.ts
+++ b/src/main/services/flac/mappers/flac-write-mapper.ts
@@ -1,4 +1,3 @@
-import { FlacMetadata } from '@domain/flac/models';
 import {
   CanonicalTagKey,
   MULTI_VALUE_PROPERTY_MAP,
@@ -7,7 +6,7 @@ import {
   SingleValueCanonicalTagKey,
   TAG_DEFINITIONS
 } from '@domain/audio/tag-definitions';
-
+import { FlacMetadata } from '@domain/flac/models';
 import {
   RawFlacData,
   RawFlacTags,

--- a/src/main/services/flac/reader.ts
+++ b/src/main/services/flac/reader.ts
@@ -1,11 +1,13 @@
 import { success } from '@domain/common/result';
-import { AppResult } from '@domain/types';
 import { appErrors } from '@domain/errors/definitions';
-
 import { FlacTrack } from '@domain/flac/models';
-import { toAppResultFailure } from '@main/utils/error-handler';
+import { AppResult } from '@domain/types';
+import { logger } from '@main/infrastructure/logging/logger';
 import { readRawFlacData } from '@main/infrastructure/repositories/flac/flac-read-repository';
+import { toAppResultFailure } from '@main/utils/error-handler';
 import { mapToFlacMetadata } from './mappers/flac-read-mapper';
+
+const LOG_CONTEXT = 'ReadMetadata';
 
 /**
  * 指定されたパスのFLACファイルからメタデータを読み取ります。
@@ -13,9 +15,13 @@ import { mapToFlacMetadata } from './mappers/flac-read-mapper';
  * 画像を実際に表示する場合は、カスタムプロトコル (flac-image://) を使用してください。
  */
 export const readMetadata = async (filePath: string): Promise<AppResult<FlacTrack>> => {
+  logger.debug({ context: LOG_CONTEXT, message: `Starting to read metadata: ${filePath}` });
   try {
     const rawData = await readRawFlacData(filePath);
+
     const metadata = mapToFlacMetadata(rawData, filePath);
+    logger.debug({ context: LOG_CONTEXT, message: `Metadata mapping completed: ${filePath}` });
+
     return success({ path: filePath, metadata });
   } catch (error: unknown) {
     return toAppResultFailure(error, appErrors.parseFailed, { path: filePath });

--- a/src/main/services/flac/renamer.ts
+++ b/src/main/services/flac/renamer.ts
@@ -1,13 +1,15 @@
+import { formatFilename } from '@domain/audio/filename-formatter';
 import { success } from '@domain/common/result';
 import { appErrors } from '@domain/errors/definitions';
-import { formatFilename } from '@domain/audio/filename-formatter';
 import type { FlacTrack } from '@domain/flac/models';
 import { AppResult } from '@domain/types';
-
-import { renameFileExclusive } from '@main/infrastructure/repositories/file/file-rename-repository';
+import { logger } from '@main/infrastructure/logging/logger';
 import { resolveNewPath } from '@main/infrastructure/repositories/file/file-path-repository';
+import { renameFileExclusive } from '@main/infrastructure/repositories/file/file-rename-repository';
 import { settingsRepository } from '@main/infrastructure/repositories/settings/settings-repository';
 import { toAppResultFailure } from '@main/utils/error-handler';
+
+const LOG_CONTEXT = 'Renamer';
 
 /**
  * ファイルを新しいパスにリネーム（移動）します。
@@ -15,6 +17,7 @@ import { toAppResultFailure } from '@main/utils/error-handler';
  * @param newPath 新しい絶対パス
  */
 export const renameFile = async (oldPath: string, newPath: string): Promise<AppResult<void>> => {
+  logger.debug({ context: LOG_CONTEXT, message: `Renaming: ${oldPath} -> ${newPath}` });
   try {
     await renameFileExclusive(oldPath, newPath);
   } catch (error: unknown) {

--- a/src/main/services/flac/scanner.ts
+++ b/src/main/services/flac/scanner.ts
@@ -1,11 +1,13 @@
 import { success } from '@domain/common/result';
-import { AppResult } from '@domain/types';
-import { ScanResult } from '@shared/flac';
 import { appErrors } from '@domain/errors/definitions';
-
+import { AppResult } from '@domain/types';
+import { logger } from '@main/infrastructure/logging/logger';
+import { scanFiles } from '@main/infrastructure/repositories/file/file-scanner-repository';
 import { toAppResultFailure } from '@main/utils/error-handler';
 import { isSupportedAudioFile } from '@main/utils/file-utils';
-import { scanFiles } from '@main/infrastructure/repositories/file/file-scanner-repository';
+import { ScanResult } from '@shared/flac';
+
+const LOG_CONTEXT = 'ScanDirectory';
 
 /**
  * 指定された複数のパス（ファイルまたはディレクトリ）から、再帰的に .flac ファイルのパスを探索します。
@@ -13,8 +15,16 @@ import { scanFiles } from '@main/infrastructure/repositories/file/file-scanner-r
  * @returns 見つかった FLAC ファイルの絶対パスの配列と制限フラグを含むオブジェクト
  */
 export const scanDirectory = async (targetPaths: string[]): Promise<AppResult<ScanResult>> => {
+  logger.debug({
+    context: LOG_CONTEXT,
+    message: `Starting to scan: ${targetPaths.join(', ')}`
+  });
   try {
     const result = await scanFiles(targetPaths, (name) => isSupportedAudioFile(name));
+    logger.debug({
+      context: LOG_CONTEXT,
+      message: `Scan completed: found ${result.paths.length} files`
+    });
     return success(result);
   } catch (error: unknown) {
     const representativePath = targetPaths[0] ?? '';

--- a/src/main/services/flac/writer.ts
+++ b/src/main/services/flac/writer.ts
@@ -2,24 +2,29 @@ import { success } from '@domain/common/result';
 import { appErrors } from '@domain/errors/definitions';
 import { FlacTrack } from '@domain/flac/models';
 import { AppResult } from '@domain/types';
-
-import { toAppResultFailure } from '@main/utils/error-handler';
+import { logger } from '@main/infrastructure/logging/logger';
 import { readRawFlacData } from '@main/infrastructure/repositories/flac/flac-read-repository';
 import { writeFlacTagsWithAtomic } from '@main/infrastructure/repositories/flac/flac-write-repository';
+import { toAppResultFailure } from '@main/utils/error-handler';
 import { mergeMetadataWithTags } from './mappers/flac-write-mapper';
 import { resolvePictureForWrite } from './mappers/flac-write-picture-resolver';
+
+const LOG_CONTEXT = 'WriteMetadata';
 
 /**
  * 指定されたパスのFLACファイルへメタデータを書き込みます。
  */
 export const writeMetadata = async (track: FlacTrack): Promise<AppResult<string>> => {
   const { path, metadata } = track;
+  logger.debug({ context: LOG_CONTEXT, message: `Starting to write metadata: ${path}` });
 
   try {
     const rawData = await readRawFlacData(path);
     const picture = await resolvePictureForWrite(metadata.picture, rawData);
     const mergedTags = mergeMetadataWithTags(rawData, metadata, picture);
     await writeFlacTagsWithAtomic(path, mergedTags);
+
+    logger.debug({ context: LOG_CONTEXT, message: `Write completed: ${path}` });
   } catch (error: unknown) {
     return toAppResultFailure(error, appErrors.writeFailed, { path });
   }

--- a/src/renderer/src/components/SettingsModal.svelte
+++ b/src/renderer/src/components/SettingsModal.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { TAG_PLACEHOLDERS } from '@domain/audio/constants';
-  import { FilePen, List, Save, Star, X } from '@lucide/svelte';
+  import { Bug, FilePen, List, Save, Star, X } from '@lucide/svelte';
   import { UI_TOKENS } from '@renderer/constants/design-system';
   import { MAX_QUICK_GENRES, settingsStore } from '@renderer/stores/settings-store.svelte';
   import { uiState } from '@renderer/stores/ui-state.svelte';
-  import { type ColorTheme } from '@shared/settings';
+  import { type ColorTheme, type LogLevel } from '@shared/settings';
   import BadgeField from './ui/BadgeField.svelte';
   import Modal from './ui/Modal.svelte';
 
@@ -20,6 +20,7 @@
   };
 
   const themes: ColorTheme[] = ['light', 'dark', 'system'];
+  const logLevels: LogLevel[] = ['INFO', 'DEBUG'];
 </script>
 
 <Modal isOpen={uiState.isSettingsOpen} onClose={handleCancel} title="Settings">
@@ -28,7 +29,7 @@
       <!-- Section: Appearance -->
       <section class="settings-section">
         <div class="field">
-          <div class="theme-toggle" id="setting-theme">
+          <div class="toggle-group" id="setting-theme">
             {#each themes as theme (theme)}
               <button
                 type="button"
@@ -37,6 +38,28 @@
                 onclick={() => settingsStore.update('theme', theme)}
               >
                 {theme}
+              </button>
+            {/each}
+          </div>
+        </div>
+      </section>
+
+      <!-- Section: Logging (Debug) -->
+      <section class="settings-section">
+        <div class="section-header">
+          <Bug size={UI_TOKENS.icons.size} />
+          <h3>Logging</h3>
+        </div>
+        <div class="field">
+          <div class="toggle-group" id="setting-log-level">
+            {#each logLevels as level (level)}
+              <button
+                type="button"
+                class="toggle-btn"
+                class:active={settingsStore.current.logLevel === level}
+                onclick={() => settingsStore.update('logLevel', level)}
+              >
+                {level}
               </button>
             {/each}
           </div>
@@ -246,7 +269,7 @@
     appearance: textfield;
   }
 
-  .theme-toggle {
+  .toggle-group {
     display: flex;
     background-color: var(--bg-secondary);
     padding: 0.25rem;

--- a/src/renderer/src/components/SettingsModal.svelte
+++ b/src/renderer/src/components/SettingsModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { TAG_PLACEHOLDERS } from '@domain/audio/constants';
-  import { Bug, FilePen, List, Save, Star, X } from '@lucide/svelte';
+  import { FilePen, List, Logs, Palette, Save, Star, X } from '@lucide/svelte';
   import { UI_TOKENS } from '@renderer/constants/design-system';
   import { MAX_QUICK_GENRES, settingsStore } from '@renderer/stores/settings-store.svelte';
   import { uiState } from '@renderer/stores/ui-state.svelte';
@@ -23,11 +23,15 @@
   const logLevels: LogLevel[] = ['INFO', 'DEBUG'];
 </script>
 
-<Modal isOpen={uiState.isSettingsOpen} onClose={handleCancel} title="Settings">
+<Modal isOpen={uiState.isSettingsOpen} onClose={handleCancel} title="Settings" maxWidth="640px">
   {#if settingsStore.current}
     <div class="settings-content">
       <!-- Section: Appearance -->
       <section class="settings-section">
+        <div class="section-header">
+          <Palette size={UI_TOKENS.icons.size} />
+          <h3>Appearance</h3>
+        </div>
         <div class="field">
           <div class="toggle-group" id="setting-theme">
             {#each themes as theme (theme)}
@@ -47,7 +51,7 @@
       <!-- Section: Logging (Debug) -->
       <section class="settings-section">
         <div class="section-header">
-          <Bug size={UI_TOKENS.icons.size} />
+          <Logs size={UI_TOKENS.icons.size} />
           <h3>Logging</h3>
         </div>
         <div class="field">
@@ -192,6 +196,7 @@
     font-size: 0.95rem;
     font-weight: 600;
     letter-spacing: 0.02em;
+    color: var(--text-primary);
   }
 
   .placeholder-list {

--- a/src/renderer/src/components/ui/Modal.svelte
+++ b/src/renderer/src/components/ui/Modal.svelte
@@ -14,9 +14,11 @@
     children: Snippet;
     /** フッター部分のスニペット */
     footer?: Snippet;
+    /** 最大横幅（デフォルト: 480px） */
+    maxWidth?: string;
   }
 
-  let { isOpen, onClose, title, header, children, footer }: Props = $props();
+  let { isOpen, onClose, title, header, children, footer, maxWidth = '480px' }: Props = $props();
 
   let dialog: HTMLDialogElement;
 
@@ -57,6 +59,7 @@
   oncancel={handleCancel}
   onclick={handleBackdropClick}
   class="custom-modal"
+  style="max-width: {maxWidth}"
 >
   <div class="modal-container" role="document">
     <header class="modal-header">
@@ -89,7 +92,6 @@
       0 20px 25px -5px rgba(0, 0, 0, 0.4),
       0 10px 10px -5px rgba(0, 0, 0, 0.2);
     color: var(--text-primary);
-    max-width: 480px;
     width: 90%;
     border: 1px solid var(--border-primary);
     overflow: hidden;

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1,4 +1,5 @@
 export type ColorTheme = 'light' | 'dark' | 'system';
+export type LogLevel = 'INFO' | 'DEBUG';
 
 /**
  * アプリケーションのユーザー設定の型定義。
@@ -10,6 +11,8 @@ export interface AppSettings {
   trackNumberPadding: number;
   /** カラーテーマ */
   theme: ColorTheme;
+  /** ログレベル */
+  logLevel: LogLevel;
   /** ジャンル一覧 */
   genres: string[];
   /** クイックジャンルボタンの設定（表示するジャンル名） */


### PR DESCRIPTION
GitHub Issue #179 に基づき、アプリケーションのデバッグログを強化・整理し、さらに設定画面からの動的なログレベル変更機能を実装しました。本対応はマイナーアップデート（v1.5.0）としてリリースします。

### 変更内容
#### 1. デバッグログの強化と整理
- **主要なサービス層へのログ追加**: メタデータの読み書き、スキャン、リネーム、画像抽出の各フェーズで `logger.debug` による追跡を可能にしました。
- **ログコンテキストの共通化**: ファイルごとに `LOG_CONTEXT` 定数を定義し、ログのフィルタリングや追跡を容易にしました。
- **ログ出力の最適化**: 
    - ユーザーフィードバックに基づき、過剰なログ出力を抑制。
    - サービス層とリポジトリ層での重複を排除。
    - 低レイヤー（ファイル操作等）の詳細すぎる進捗ログを削除し、ノイズを低減。

#### 2. 設定画面からのログレベル変更機能
- **動的なログレベル反映**: 設定画面（Settings）から `INFO` と `DEBUG` を切り替えられるようにしました。
- **OCP対応のサブスクライブパターン**: 
    - `SettingsRepository` にイベント発行機能を追加。
    - `Logger` が設定変更を購読して自動的にログレベルを更新するようにし、各モジュール間の結合度を下げました。

#### 3. UI/UX の改善
- **設定モーダルの刷新**:
    - モーダルの横幅を拡大（480px -> 640px）し、窮屈さを解消。
    - 「Appearance」と「Logging」セクションに適切なアイコン（Palette, Logs）とヘッダーを追加。
    - セクションヘッダーのテキストカラーを調整し、視認性を向上。

#### 4. その他
- **package.json**: バージョンを **1.5.0** に更新。

### 検証内容
- `pnpm lint`: PASS
- `pnpm test`: PASS
- `pnpm build`: PASS
- 開発・本番両環境で設定変更が即座にロガーに反映され、UI が適切に表示されることを確認。
