### PR TITLE
feat: Windows (portable) および Linux 向けのリリースを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,17 +40,15 @@ jobs:
             echo "Release $TAG does not exist. Proceeding with build."
           fi
 
-  build-and-release:
+  build-mac:
     needs: check-release
     if: needs.check-release.outputs.should_release == 'true'
     runs-on: macos-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: リポジトリのチェックアウト
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Node.js のセットアップ
         uses: actions/setup-node@v6
@@ -65,17 +63,109 @@ jobs:
       - name: 依存関係のインストール
         run: pnpm install
 
-      - name: ビルドおよび公証
+      - name: ビルドおよび公証 (Mac)
         run: pnpm build:mac
         env:
-          # コード署名
           CSC_LINK: ${{ secrets.MACOS_CERTIFICATE }}
           CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-          # 公証
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: アーティファクトのアップロード
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts-mac
+          path: |
+            dist/*.dmg
+            dist/*.zip
+            dist/latest-mac.yml
+
+  build-win:
+    needs: check-release
+    if: needs.check-release.outputs.should_release == 'true'
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: リポジトリのチェックアウト
+        uses: actions/checkout@v6
+
+      - name: Node.js のセットアップ
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: pnpm のセットアップ
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+
+      - name: 依存関係のインストール
+        run: pnpm install
+
+      - name: ビルド (Windows)
+        run: pnpm build:win
+
+      - name: アーティファクトのアップロード
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts-win
+          path: |
+            dist/*.exe
+            dist/latest.yml
+
+  build-linux:
+    needs: check-release
+    if: needs.check-release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: リポジトリのチェックアウト
+        uses: actions/checkout@v6
+
+      - name: Node.js のセットアップ
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: pnpm のセットアップ
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+
+      - name: 依存関係のインストール
+        run: pnpm install
+
+      - name: ビルド (Linux)
+        run: pnpm build:linux
+
+      - name: アーティファクトのアップロード
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts-linux
+          path: |
+            dist/*.AppImage
+            dist/*.deb
+            dist/latest-linux.yml
+
+  release:
+    needs: [check-release, build-mac, build-win, build-linux]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: リポジトリのチェックアウト
+        uses: actions/checkout@v6
+
+      - name: アーティファクトのダウンロード
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-artifacts-*
+          path: dist
+          merge-multiple: true
 
       - name: GitHub リリースの作成
         env:
@@ -89,9 +179,7 @@ jobs:
             --title "$TAG" \
             --notes "$PR_DATA" \
             --target main \
-            dist/*.dmg \
-            dist/*.zip \
-            dist/latest-mac.yml
+            dist/*
 
       - name: 旧バージョンの判定
         id: check_old_release

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -16,11 +16,16 @@ asarUnpack:
   - resources/**
 win:
   executableName: TagUtil
+  target:
+    - nsis
+    - portable
 nsis:
   artifactName: ${productName}-${version}-setup.${ext}
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
+portable:
+  artifactName: ${productName}-${version}-portable.${ext}
 mac:
   entitlementsInherit: build/entitlements.mac.plist
   hardenedRuntime: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",
@@ -39,6 +39,7 @@
     "build:unpack": "pnpm build && dotenv -- electron-builder --dir",
     "build:win": "pnpm build && electron-builder --win --publish never",
     "build:mac": "pnpm build && electron-builder --mac --publish never",
+    "build:linux": "pnpm build && electron-builder --linux --publish never",
     "sign": "dotenv -- pnpm build:mac",
     "test": "vitest run --coverage",
     "release": "pnpm version patch && git push origin main --follow-tags"


### PR DESCRIPTION
## 概要
GitHub Issue #158 に対応し、Windows（ポータブル版）およびLinux向けのリリースパッケージを追加しました。また、リリースワークフローをマルチプラットフォーム対応にリファクタリングしました。

## 変更内容
- **ビルド設定の追加 (`electron-builder.yml`)**:
    - Windowsターゲットに `portable` を追加。
    - ポータブル版のアーティファクト名を設定。
- **スクリプトの追加 (`package.json`)**:
    - `build:linux` スクリプトを追加。
- **ワークフローのリファクタリング (`release.yml`)**:
    - ビルドジョブを `build-mac`, `build-win`, `build-linux` に分割。
    - 各OSのビルド成果物を統合して1つのGitHubリリースとして公開するよう改善。
- **バージョンアップ**:
    - `1.5.1` に更新。

## 検証結果
- `pnpm build`: 正常終了を確認済み。
- `git push`: ワークフローファイルを含め、正常にリモートへ反映済み。

## 備考
トラブルシューティング中に作成してしまった `TEST.md` は、強制プッシュにより削除済みです。