### PR TITLE
feat(test): E2Eテストの実装 (Issue #185)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.5.4",
+  "version": "1.5.3",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/tests/e2e/pom/InspectorArea.ts
+++ b/tests/e2e/pom/InspectorArea.ts
@@ -1,0 +1,15 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export class InspectorArea {
+  readonly root: Locator;
+  readonly emptyState: Locator;
+
+  constructor(page: Page) {
+    this.root = page.locator('aside.inspector');
+    this.emptyState = this.root.locator('.empty-inspector');
+  }
+
+  async isEditingEnabled(): Promise<boolean> {
+    return await this.emptyState.isHidden();
+  }
+}

--- a/tests/e2e/pom/MainPage.ts
+++ b/tests/e2e/pom/MainPage.ts
@@ -1,12 +1,26 @@
 import { type Page } from '@playwright/test';
 import { join } from 'path';
 import { SCREENSHOT_DIR } from '../constants';
+import { InspectorArea } from './InspectorArea';
+import { StatusBarArea } from './StatusBarArea';
+import { ToolbarArea } from './ToolbarArea';
+import { TrackGridArea } from './TrackGridArea';
 
 /**
  * メイン画面の Page Object Model
  */
 export class MainPage {
-  constructor(private readonly page: Page) {}
+  readonly toolbar: ToolbarArea;
+  readonly trackGrid: TrackGridArea;
+  readonly inspector: InspectorArea;
+  readonly statusBar: StatusBarArea;
+
+  constructor(private readonly page: Page) {
+    this.toolbar = new ToolbarArea(page);
+    this.trackGrid = new TrackGridArea(page);
+    this.inspector = new InspectorArea(page);
+    this.statusBar = new StatusBarArea(page);
+  }
 
   /**
    * ウィンドウのタイトルを取得する

--- a/tests/e2e/pom/StatusBarArea.ts
+++ b/tests/e2e/pom/StatusBarArea.ts
@@ -1,0 +1,17 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export class StatusBarArea {
+  readonly root: Locator;
+  readonly toggleButton: Locator;
+  readonly logPanel: Locator;
+
+  constructor(page: Page) {
+    this.root = page.locator('footer.status-bar');
+    this.toggleButton = this.root.locator('.main-bar');
+    this.logPanel = this.root.locator('.log-panel');
+  }
+
+  async toggleLogs(): Promise<void> {
+    await this.toggleButton.click();
+  }
+}

--- a/tests/e2e/pom/ToolbarArea.ts
+++ b/tests/e2e/pom/ToolbarArea.ts
@@ -1,0 +1,19 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export class ToolbarArea {
+  readonly root: Locator;
+  readonly openDirectoryButton: Locator;
+  readonly renameFilesButton: Locator;
+  readonly revertChangesButton: Locator;
+  readonly saveChangesButton: Locator;
+  readonly settingsButton: Locator;
+
+  constructor(page: Page) {
+    this.root = page.locator('header.toolbar');
+    this.openDirectoryButton = this.root.locator('button[title="Open Directory"]');
+    this.renameFilesButton = this.root.locator('button[title="Rename Files from Metadata"]');
+    this.revertChangesButton = this.root.locator('button[title="Revert Changes"]');
+    this.saveChangesButton = this.root.locator('button[title="Save Changes"]');
+    this.settingsButton = this.root.locator('button[title="Settings"]');
+  }
+}

--- a/tests/e2e/pom/TrackGridArea.ts
+++ b/tests/e2e/pom/TrackGridArea.ts
@@ -1,0 +1,23 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export class TrackGridArea {
+  readonly root: Locator;
+  readonly emptyState: Locator;
+  readonly openDirectoryButton: Locator;
+  readonly rows: Locator;
+
+  constructor(page: Page) {
+    this.root = page.locator('.grid-wrapper');
+    this.emptyState = this.root.locator('.empty-state');
+    this.openDirectoryButton = this.emptyState.locator('button[aria-label="Open Directory"]');
+    this.rows = this.root.locator('tr.track-row');
+  }
+
+  async getTrackCount(): Promise<number> {
+    return await this.rows.count();
+  }
+
+  async selectTrack(index: number): Promise<void> {
+    await this.rows.nth(index).click();
+  }
+}

--- a/tests/e2e/specs/app.spec.ts
+++ b/tests/e2e/specs/app.spec.ts
@@ -1,9 +1,35 @@
 import { e2eTest, expect } from '../fixtures';
 
-e2eTest('アプリケーションが起動し、タイトルが正しいこと', async ({ mainPage }) => {
-  // タイトルの確認
-  expect(await mainPage.getTitle()).toBe('TagUtil');
+e2eTest.describe('App Initialization', () => {
+  e2eTest('アプリケーションが起動し、初期状態が正しいこと', async ({ mainPage }) => {
+    // タイトルの確認
+    expect(await mainPage.getTitle()).toBe('TagUtil');
 
-  // スクリーンショットの撮影（デバッグ用）
-  await mainPage.screenshot('initial-load');
+    // ツールバーの初期状態（ファイルが読み込まれていないので無効化されているべき）
+    await expect(mainPage.toolbar.renameFilesButton).toBeDisabled();
+    await expect(mainPage.toolbar.revertChangesButton).toBeDisabled();
+    await expect(mainPage.toolbar.saveChangesButton).toBeDisabled();
+
+    // グリッドとインスペクターの初期状態（空）
+    await expect(mainPage.trackGrid.emptyState).toBeVisible();
+    expect(await mainPage.trackGrid.getTrackCount()).toBe(0);
+
+    expect(await mainPage.inspector.isEditingEnabled()).toBe(false);
+    await expect(mainPage.inspector.emptyState).toBeVisible();
+
+    await mainPage.screenshot('initial-state');
+  });
+
+  e2eTest('ステータスバーのログパネルの開閉ができること', async ({ mainPage }) => {
+    // 初期状態は開いている (App.svelte 等の実装による)
+    // ログパネルの表示をトグルする
+    await mainPage.statusBar.toggleLogs();
+
+    // パネルが閉じたことを確認
+    await expect(mainPage.statusBar.logPanel).toBeHidden();
+
+    // 再度トグル
+    await mainPage.statusBar.toggleLogs();
+    await expect(mainPage.statusBar.logPanel).toBeVisible();
+  });
 });

--- a/tests/e2e/specs/app.spec.ts
+++ b/tests/e2e/specs/app.spec.ts
@@ -17,19 +17,23 @@ e2eTest.describe('App Initialization', () => {
     expect(await mainPage.inspector.isEditingEnabled()).toBe(false);
     await expect(mainPage.inspector.emptyState).toBeVisible();
 
-    await mainPage.screenshot('initial-state');
+    await mainPage.screenshot('アプリ起動直後の初期状態');
   });
 
   e2eTest('ステータスバーのログパネルの開閉ができること', async ({ mainPage }) => {
     // 初期状態は開いている (App.svelte 等の実装による)
+    await mainPage.screenshot('ログパネル開閉テスト_初期状態');
+
     // ログパネルの表示をトグルする
     await mainPage.statusBar.toggleLogs();
 
     // パネルが閉じたことを確認
     await expect(mainPage.statusBar.logPanel).toBeHidden();
+    await mainPage.screenshot('ログパネルを閉じた状態');
 
     // 再度トグル
     await mainPage.statusBar.toggleLogs();
     await expect(mainPage.statusBar.logPanel).toBeVisible();
+    await mainPage.screenshot('ログパネルを再度開いた状態');
   });
 });


### PR DESCRIPTION
This PR resolves #185 by implementing the foundation of E2E tests using POM and Fixtures.

## 実施したこと
- 各セクションごとのPage Object Model (POM) の定義を作成
  - `ToolbarArea`
  - `TrackGridArea`
  - `InspectorArea`
  - `StatusBarArea`
- `MainPage` にPOMを統合
- 初期状態が正しいことを確認する基本的なテストケースの実装
- `pnpm test:e2e` でテストがパスすることを確認

## 検証内容
- `pnpm format`, `pnpm lint` による静的解析のパス
- `pnpm build` によるビルドの成功
- `pnpm test` によるユニットテストのパス
- `pnpm test:e2e` が2つのE2Eテストで成功することを確認