### PR TITLE
refactor: SelectionStateのカプセル化とSettingsStoreテストの修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag-util",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Functional FLAC metadata editor with Svelte 5 TagState",
   "type": "module",
   "main": "./out/main/index.js",

--- a/src/renderer/src/infrastructure/repositories/settings-repository.test.ts
+++ b/src/renderer/src/infrastructure/repositories/settings-repository.test.ts
@@ -19,6 +19,7 @@ describe('settings-repository', () => {
         renamePattern: '{title}',
         trackNumberPadding: 3,
         theme: 'dark',
+        logLevel: 'INFO',
         genres: [],
         quickGenres: []
       };

--- a/src/renderer/src/services/file-actions.test.ts
+++ b/src/renderer/src/services/file-actions.test.ts
@@ -17,7 +17,7 @@ describe('fileActions', () => {
     vi.clearAllMocks();
     uiState.stopLoading();
     trackStore.tracks = [];
-    selectionState.items.clear();
+    selectionState.clear();
     vi.spyOn(tagRepository, 'readMetadata');
     vi.spyOn(fileRepository, 'renameFile');
     vi.spyOn(pathAdapter, 'generateNewPath').mockResolvedValue(success('/dir/new.flac'));

--- a/src/renderer/src/services/file-actions.ts
+++ b/src/renderer/src/services/file-actions.ts
@@ -27,7 +27,7 @@ const renameSelectedFiles = async (): Promise<void> => {
     // 成功したファイルがあればストアを差し替え
     if (renamedMap.size > 0) {
       trackStore.tracks = trackStore.tracks.map((t) => renamedMap.get(t.path) ?? t);
-      selectionState.items.clear();
+      selectionState.clear();
     }
   } finally {
     uiState.stopLoading();

--- a/src/renderer/src/stores/selection-state.svelte.ts
+++ b/src/renderer/src/stores/selection-state.svelte.ts
@@ -7,42 +7,55 @@ import { TrackRecord } from './track-record.svelte';
  * 内部的には TrackRecord インスタンスの参照を SvelteSet で管理します。
  */
 class SelectionState {
-  items = new SvelteSet<TrackRecord>();
+  #items = new SvelteSet<TrackRecord>();
   /** 最後に選択（クリックやキー移動）されたトラックのインデックス */
-  lastSelectedIndex = $state<number | null>(null);
+  #lastSelectedIndex = $state<number | null>(null);
+
+  get items(): ReadonlySet<TrackRecord> {
+    return this.#items;
+  }
+
+  get lastSelectedIndex(): number | null {
+    return this.#lastSelectedIndex;
+  }
 
   /** 特定のトラックが選択されているかどうかを返します */
   has(track: TrackRecord): boolean {
-    return this.items.has(track);
+    return this.#items.has(track);
   }
 
   selectSingle(track: TrackRecord, index: number): void {
-    this.items.clear();
-    this.items.add(track);
-    this.lastSelectedIndex = index;
+    this.#items.clear();
+    this.#items.add(track);
+    this.#lastSelectedIndex = index;
   }
 
   selectRange(tracks: TrackRecord[]): void {
     for (const track of tracks) {
-      this.items.add(track);
+      this.#items.add(track);
     }
   }
 
   selectAll(tracks: TrackRecord[]): void {
     for (const track of tracks) {
-      this.items.add(track);
+      this.#items.add(track);
     }
-    this.lastSelectedIndex = tracks.length > 0 ? tracks.length - 1 : null;
+    this.#lastSelectedIndex = tracks.length > 0 ? tracks.length - 1 : null;
   }
 
   selectNext(tracks: TrackRecord[]): void {
-    const next = this.lastSelectedIndex === null ? 0 : this.lastSelectedIndex + 1;
+    const next = this.#lastSelectedIndex === null ? 0 : this.#lastSelectedIndex + 1;
     this.#selectIndex(next, tracks);
   }
 
   selectPrevious(tracks: TrackRecord[]): void {
-    const prev = this.lastSelectedIndex === null ? tracks.length - 1 : this.lastSelectedIndex - 1;
+    const prev = this.#lastSelectedIndex === null ? tracks.length - 1 : this.#lastSelectedIndex - 1;
     this.#selectIndex(prev, tracks);
+  }
+
+  clear(): void {
+    this.#items.clear();
+    this.#lastSelectedIndex = null;
   }
 
   #selectIndex(index: number, tracks: TrackRecord[]): void {

--- a/src/renderer/src/stores/selection-state.test.ts
+++ b/src/renderer/src/stores/selection-state.test.ts
@@ -14,8 +14,7 @@ describe('SelectionState', () => {
   ];
 
   beforeEach(() => {
-    selectionState.items.clear();
-    selectionState.lastSelectedIndex = null;
+    selectionState.clear();
   });
 
   it('初期状態では選択がなく、インデックスも null であること', () => {

--- a/src/renderer/src/stores/settings-store.svelte.test.ts
+++ b/src/renderer/src/stores/settings-store.svelte.test.ts
@@ -11,6 +11,7 @@ const mockDefaultSettings: AppSettings = {
   renamePattern: '{trackNumber} - {title}',
   trackNumberPadding: 2,
   theme: 'system',
+  logLevel: 'INFO',
   genres: ['Rock'],
   quickGenres: ['Rock']
 };
@@ -23,6 +24,7 @@ vi.mock('@renderer/infrastructure/repositories/settings-repository', () => ({
         renamePattern: '{trackNumber} - {title}',
         trackNumberPadding: 2,
         theme: 'system',
+        logLevel: 'INFO',
         genres: ['Rock'],
         quickGenres: ['Rock']
       }


### PR DESCRIPTION
SelectionState のプロパティをプライベートフィールド（#）でカプセル化し、外部からの直接更新を制限しました。また、SettingsStore のテストにおいて AppSettings 型に不足していた logLevel プロパティを追加し、テストエラーを修正しました。

### 変更内容
- SelectionState の `items`, `lastSelectedIndex` をカプセル化し、読み取り専用のゲッターを提供
- SelectionState に状態リセット用の `clear()` メソッドを追加
- SelectionState の各メソッド（selectSingle等）を内部のプライベートフィールドを使用するように修正
- SettingsStore のテスト（`settings-store.svelte.test.ts`, `settings-repository.test.ts`）における AppSettings Mock に `logLevel` を追加

### 検証内容
- `pnpm test` ですべてのテストがパスすることを確認済み
- `pnpm lint` でプロジェクト全体のコード規約を遵守していることを確認済み
- `pnpm format` によるフォーマット済み