### PR TITLE
test: タグ書き込み機能のE2Eテストを実装 (#185)

### DIFF
--- a/tests/e2e/pom/InspectorArea.ts
+++ b/tests/e2e/pom/InspectorArea.ts
@@ -1,92 +1,28 @@
 import { type Locator, type Page } from '@playwright/test';
 import { DropZoneArea } from './DropZoneArea';
+import { ArtworkSection } from './inspector/ArtworkSection';
+import { BasicFieldsSection } from './inspector/BasicFieldsSection';
+import { GenreSection } from './inspector/GenreSection';
+import { NumericFieldsSection } from './inspector/NumericFieldsSection';
 
 export class InspectorArea {
   readonly root: Locator;
   readonly dropZone: DropZoneArea;
   readonly emptyState: Locator;
-  readonly titleInput: Locator;
-  readonly artistInput: Locator;
-  readonly albumInput: Locator;
-  readonly albumArtistInput: Locator;
-  readonly genreInput: Locator;
-  readonly trackNumberInput: Locator;
-  readonly discNumberInput: Locator;
-  readonly discTotalInput: Locator;
-  readonly trackTotalInput: Locator;
-  readonly dateInput: Locator;
-  readonly catalogNumberInput: Locator;
-  readonly coverArt: Locator;
-  readonly coverPlaceholder: Locator;
-  readonly coverPlaceholderText: Locator;
+
+  readonly artwork: ArtworkSection;
+  readonly basicFields: BasicFieldsSection;
+  readonly numericFields: NumericFieldsSection;
+  readonly genres: GenreSection;
 
   constructor(public readonly page: Page) {
     this.root = page.getByTestId('inspector');
     this.dropZone = new DropZoneArea(page, page.getByTestId('inspector-drop-zone'));
     this.emptyState = page.getByTestId('inspector-empty');
-    this.coverArt = page.getByTestId('cover-art');
-    this.coverPlaceholder = page.getByTestId('cover-placeholder');
-    this.coverPlaceholderText = page.getByTestId('cover-placeholder-text');
 
-    // 単一値フィールド (ラベルで検索するため root 経由を維持)
-    this.titleInput = this.root.getByLabel('Title', { exact: true });
-    this.albumInput = this.root.getByLabel('Album', { exact: true });
-    this.genreInput = this.root.getByLabel('Genre', { exact: true });
-    this.dateInput = this.root.getByLabel('Date', { exact: true });
-    this.trackNumberInput = this.root.getByLabel('Track', { exact: true });
-    this.trackTotalInput = this.root.getByPlaceholder('Tracks', { exact: true });
-    this.discNumberInput = this.root.getByLabel('Disc', { exact: true });
-    this.discTotalInput = this.root.getByPlaceholder('Discs', { exact: true });
-    this.catalogNumberInput = this.root.getByLabel('Catalog Number', { exact: true });
-
-    // マルチバリューフィールド (MultiValueField.svelte)
-    this.artistInput = this.root.getByLabel('Artist', { exact: true });
-    this.albumArtistInput = this.root.getByLabel('Album Artist', { exact: true });
-  }
-
-  /**
-   * アーティストの値を取得します。
-   */
-  async getArtists(): Promise<string[]> {
-    return this.getMultiFieldValues('Artist');
-  }
-
-  /**
-   * アルバムアーティストの値を取得します。
-   */
-  async getAlbumArtists(): Promise<string[]> {
-    return this.getMultiFieldValues('Album Artist');
-  }
-
-  /**
-   * ジャンルの値を取得します。
-   */
-  async getGenres(): Promise<string[]> {
-    return this.getMultiFieldValues('Genre');
-  }
-
-  /**
-   * 指定したラベルを持つ MultiValueField または BadgeField のすべての入力値を取得します。
-   */
-  private async getMultiFieldValues(label: string): Promise<string[]> {
-    const testIdBase = label.toLowerCase().replace(/\s+/g, '-');
-    const container = this.root.getByTestId(`${testIdBase}-field`);
-    await container.waitFor({ state: 'visible', timeout: 10000 });
-
-    const classList = (await container.getAttribute('class')) || '';
-
-    if (classList.includes('multi-value-field')) {
-      // MultiValueField (input要素) の場合
-      const inputs = container.locator('input[type="text"]');
-      return inputs.evaluateAll((elems) => elems.map((el) => (el as HTMLInputElement).value));
-    }
-
-    if (classList.includes('badge-field')) {
-      // BadgeField (badge-item要素) の場合
-      // Xボタンなどのテキストを除外するため、badge内のテキストのみを取得
-      return container.getByTestId('badge-item').allInnerTexts();
-    }
-
-    return [];
+    this.artwork = new ArtworkSection(page, this.root);
+    this.basicFields = new BasicFieldsSection(page, this.root);
+    this.numericFields = new NumericFieldsSection(page, this.root);
+    this.genres = new GenreSection(page, this.root);
   }
 }

--- a/tests/e2e/pom/TrackGridArea.ts
+++ b/tests/e2e/pom/TrackGridArea.ts
@@ -24,6 +24,13 @@ export class TrackGridArea {
   }
 
   /**
+   * すべてのトラックを選択します。
+   */
+  async selectAll(): Promise<void> {
+    await this.page.keyboard.press('Control+A');
+  }
+
+  /**
    * 現在表示されているすべてのトラックのタイトルを取得します。
    */
   async getTitles(): Promise<string[]> {

--- a/tests/e2e/pom/inspector/ArtworkSection.ts
+++ b/tests/e2e/pom/inspector/ArtworkSection.ts
@@ -1,0 +1,16 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export class ArtworkSection {
+  readonly coverArt: Locator;
+  readonly coverPlaceholder: Locator;
+  readonly coverPlaceholderText: Locator;
+
+  constructor(
+    public readonly page: Page,
+    public readonly root: Locator
+  ) {
+    this.coverArt = this.root.getByTestId('cover-art');
+    this.coverPlaceholder = this.root.getByTestId('cover-placeholder');
+    this.coverPlaceholderText = this.root.getByTestId('cover-placeholder-text');
+  }
+}

--- a/tests/e2e/pom/inspector/BasicFieldsSection.ts
+++ b/tests/e2e/pom/inspector/BasicFieldsSection.ts
@@ -1,0 +1,88 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export class BasicFieldsSection {
+  readonly titleInput: Locator;
+  readonly artistInput: Locator;
+  readonly albumInput: Locator;
+  readonly albumArtistInput: Locator;
+  readonly catalogNumberInput: Locator;
+
+  constructor(
+    public readonly page: Page,
+    public readonly root: Locator
+  ) {
+    this.titleInput = this.root.getByLabel('Title', { exact: true });
+    this.albumInput = this.root.getByLabel('Album', { exact: true });
+    this.catalogNumberInput = this.root.getByLabel('Catalog Number', { exact: true });
+    this.artistInput = this.root.getByLabel('Artist', { exact: true });
+    this.albumArtistInput = this.root.getByLabel('Album Artist', { exact: true });
+  }
+
+  async setTitle(value: string): Promise<void> {
+    await this.fillInput(this.titleInput, value);
+  }
+
+  async setAlbum(value: string): Promise<void> {
+    await this.fillInput(this.albumInput, value);
+  }
+
+  async setCatalogNumber(value: string): Promise<void> {
+    await this.fillInput(this.catalogNumberInput, value);
+  }
+
+  async setArtists(values: string[]): Promise<void> {
+    await this.setMultiValueField('artist-field', values);
+  }
+
+  async setAlbumArtists(values: string[]): Promise<void> {
+    await this.setMultiValueField('album-artist-field', values);
+  }
+
+  async getArtists(): Promise<string[]> {
+    return this.getMultiValueFieldValues('artist-field');
+  }
+
+  async getAlbumArtists(): Promise<string[]> {
+    return this.getMultiValueFieldValues('album-artist-field');
+  }
+
+  private async fillInput(locator: Locator, value: string): Promise<void> {
+    await locator.scrollIntoViewIfNeeded();
+    await locator.fill(value);
+    await locator.press('Enter');
+    await this.page.waitForTimeout(100);
+  }
+
+  private async setMultiValueField(testId: string, values: string[]): Promise<void> {
+    const container = this.root.getByTestId(testId);
+    await container.scrollIntoViewIfNeeded();
+
+    const removeButtons = container.locator('button.remove-button');
+    let count = await removeButtons.count();
+    while (count > 0) {
+      await removeButtons.first().click({ force: true });
+      await this.page.waitForTimeout(100);
+      count = await removeButtons.count();
+    }
+
+    const addButton = container.getByTitle('Add value');
+    for (const value of values) {
+      await addButton.scrollIntoViewIfNeeded();
+      await addButton.click({ force: true });
+      await this.page.waitForTimeout(100);
+      const lastInput = container.locator('input[type="text"]').last();
+      await lastInput.scrollIntoViewIfNeeded();
+      await lastInput.fill(value);
+      await lastInput.press('Enter');
+      await this.page.waitForTimeout(100);
+    }
+  }
+
+  private async getMultiValueFieldValues(testId: string): Promise<string[]> {
+    const container = this.root.getByTestId(testId);
+    await container.scrollIntoViewIfNeeded();
+    await container.waitFor({ state: 'visible', timeout: 10000 });
+    const inputs = container.locator('input[type="text"]');
+    return inputs.evaluateAll((elems) => elems.map((el) => (el as HTMLInputElement).value));
+  }
+}

--- a/tests/e2e/pom/inspector/GenreSection.ts
+++ b/tests/e2e/pom/inspector/GenreSection.ts
@@ -1,0 +1,44 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export class GenreSection {
+  readonly genreInput: Locator;
+
+  constructor(
+    public readonly page: Page,
+    public readonly root: Locator
+  ) {
+    this.genreInput = this.root.getByLabel('Genre', { exact: true });
+  }
+
+  async setGenres(values: string[]): Promise<void> {
+    const container = this.root.getByTestId('genre-field');
+    await container.scrollIntoViewIfNeeded();
+
+    const removeButtons = container.locator('button.remove-btn');
+    let count = await removeButtons.count();
+    while (count > 0) {
+      await removeButtons.first().click({ force: true });
+      await this.page.waitForTimeout(100);
+      count = await removeButtons.count();
+    }
+
+    const input = container.locator('input[type="text"]');
+    for (const value of values) {
+      await input.scrollIntoViewIfNeeded();
+      await input.fill(value);
+      await input.press('Enter');
+      await this.page.waitForTimeout(100);
+    }
+  }
+
+  async getGenres(): Promise<string[]> {
+    const container = this.root.getByTestId('genre-field');
+    await container.scrollIntoViewIfNeeded();
+    await container.waitFor({ state: 'visible', timeout: 10000 });
+    return await container
+      .getByTestId('badge-item')
+      .evaluateAll((nodes) =>
+        nodes.map((node) => (node.firstChild as Text)?.textContent?.trim() || '')
+      );
+  }
+}

--- a/tests/e2e/pom/inspector/NumericFieldsSection.ts
+++ b/tests/e2e/pom/inspector/NumericFieldsSection.ts
@@ -1,0 +1,47 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export class NumericFieldsSection {
+  readonly trackNumberInput: Locator;
+  readonly trackTotalInput: Locator;
+  readonly discNumberInput: Locator;
+  readonly discTotalInput: Locator;
+  readonly dateInput: Locator;
+
+  constructor(
+    public readonly page: Page,
+    public readonly root: Locator
+  ) {
+    this.trackNumberInput = this.root.getByLabel('Track', { exact: true });
+    this.trackTotalInput = this.root.getByPlaceholder('Tracks', { exact: true });
+    this.discNumberInput = this.root.getByLabel('Disc', { exact: true });
+    this.discTotalInput = this.root.getByPlaceholder('Discs', { exact: true });
+    this.dateInput = this.root.getByLabel('Date', { exact: true });
+  }
+
+  async setTrackNumber(value: string): Promise<void> {
+    await this.fillInput(this.trackNumberInput, value);
+  }
+
+  async setTrackTotal(value: string): Promise<void> {
+    await this.fillInput(this.trackTotalInput, value);
+  }
+
+  async setDiscNumber(value: string): Promise<void> {
+    await this.fillInput(this.discNumberInput, value);
+  }
+
+  async setDiscTotal(value: string): Promise<void> {
+    await this.fillInput(this.discTotalInput, value);
+  }
+
+  async setDate(value: string): Promise<void> {
+    await this.fillInput(this.dateInput, value);
+  }
+
+  private async fillInput(locator: Locator, value: string): Promise<void> {
+    await locator.scrollIntoViewIfNeeded();
+    await locator.fill(value);
+    await locator.press('Enter');
+    await this.page.waitForTimeout(100);
+  }
+}

--- a/tests/e2e/specs/tag-reading.spec.ts
+++ b/tests/e2e/specs/tag-reading.spec.ts
@@ -17,25 +17,28 @@ test.describe('タグ読み込みテスト', () => {
     expect(titles).toContain('Test Title');
 
     // Inspector の検証 (画像あり)
-    await expect(mainPage.inspector.coverArt).toBeVisible();
-    await expect(mainPage.inspector.coverPlaceholder).not.toBeVisible();
+    await expect(mainPage.inspector.artwork.coverArt).toBeVisible();
+    await expect(mainPage.inspector.artwork.coverPlaceholder).not.toBeVisible();
 
     // Inspector の検証 (各フィールド)
-    await expect(mainPage.inspector.titleInput).toHaveValue('Test Title');
-    await expect(mainPage.inspector.albumInput).toHaveValue('Test Album');
-    await expect(mainPage.inspector.dateInput).toHaveValue('2024');
-    await expect(mainPage.inspector.trackNumberInput).toHaveValue('1');
-    await expect(mainPage.inspector.trackTotalInput).toHaveValue('10');
-    await expect(mainPage.inspector.discNumberInput).toHaveValue('2');
-    await expect(mainPage.inspector.discTotalInput).toHaveValue('3');
-    await expect(mainPage.inspector.catalogNumberInput).toHaveValue('CAT-001');
+    await expect(mainPage.inspector.basicFields.titleInput).toHaveValue('Test Title');
+    await expect(mainPage.inspector.basicFields.albumInput).toHaveValue('Test Album');
+    await expect(mainPage.inspector.numericFields.dateInput).toHaveValue('2024');
+    await expect(mainPage.inspector.numericFields.trackNumberInput).toHaveValue('1');
+    await expect(mainPage.inspector.numericFields.trackTotalInput).toHaveValue('10');
+    await expect(mainPage.inspector.numericFields.discNumberInput).toHaveValue('2');
+    await expect(mainPage.inspector.numericFields.discTotalInput).toHaveValue('3');
+    await expect(mainPage.inspector.basicFields.catalogNumberInput).toHaveValue('CAT-001');
 
-    expect(await mainPage.inspector.getArtists()).toEqual(['Test Artist 1', 'Test Artist 2']);
-    expect(await mainPage.inspector.getAlbumArtists()).toEqual([
+    expect(await mainPage.inspector.basicFields.getArtists()).toEqual([
+      'Test Artist 1',
+      'Test Artist 2'
+    ]);
+    expect(await mainPage.inspector.basicFields.getAlbumArtists()).toEqual([
       'Test Album Artist 1',
       'Test Album Artist 2'
     ]);
-    expect(await mainPage.inspector.getGenres()).toEqual(['Rock', 'Pop']);
+    expect(await mainPage.inspector.genres.getGenres()).toEqual(['Rock', 'Pop']);
   });
 
   test('タグが一切設定されていないFLACファイルを正常に読み込めること', async ({
@@ -49,21 +52,21 @@ test.describe('タグ読み込みテスト', () => {
     await mainPage.trackGrid.selectTrack(0);
 
     // Inspector の検証 (画像なし/プレースホルダー表示)
-    await expect(mainPage.inspector.coverArt).not.toBeVisible();
-    await expect(mainPage.inspector.coverPlaceholder).toBeVisible();
-    await expect(mainPage.inspector.coverPlaceholderText).toHaveText('No Artwork');
+    await expect(mainPage.inspector.artwork.coverArt).not.toBeVisible();
+    await expect(mainPage.inspector.artwork.coverPlaceholder).toBeVisible();
+    await expect(mainPage.inspector.artwork.coverPlaceholderText).toHaveText('No Artwork');
 
     // すべてのメタデータが空であることを確認
-    await expect(mainPage.inspector.titleInput).toHaveValue('');
-    await expect(mainPage.inspector.albumInput).toHaveValue('');
-    await expect(mainPage.inspector.dateInput).toHaveValue('');
-    await expect(mainPage.inspector.trackNumberInput).toHaveValue('');
-    await expect(mainPage.inspector.trackTotalInput).toHaveValue('');
-    await expect(mainPage.inspector.discNumberInput).toHaveValue('');
-    await expect(mainPage.inspector.discTotalInput).toHaveValue('');
-    await expect(mainPage.inspector.catalogNumberInput).toHaveValue('');
+    await expect(mainPage.inspector.basicFields.titleInput).toHaveValue('');
+    await expect(mainPage.inspector.basicFields.albumInput).toHaveValue('');
+    await expect(mainPage.inspector.numericFields.dateInput).toHaveValue('');
+    await expect(mainPage.inspector.numericFields.trackNumberInput).toHaveValue('');
+    await expect(mainPage.inspector.numericFields.trackTotalInput).toHaveValue('');
+    await expect(mainPage.inspector.numericFields.discNumberInput).toHaveValue('');
+    await expect(mainPage.inspector.numericFields.discTotalInput).toHaveValue('');
+    await expect(mainPage.inspector.basicFields.catalogNumberInput).toHaveValue('');
 
-    expect(await mainPage.inspector.getArtists()).toEqual([]);
-    expect(await mainPage.inspector.getGenres()).toEqual([]);
+    expect(await mainPage.inspector.basicFields.getArtists()).toEqual([]);
+    expect(await mainPage.inspector.genres.getGenres()).toEqual([]);
   });
 });

--- a/tests/e2e/specs/tag-writing.spec.ts
+++ b/tests/e2e/specs/tag-writing.spec.ts
@@ -1,0 +1,108 @@
+import { join } from 'path';
+import { expect, e2eTest as test } from '../fixtures';
+
+test.describe('タグ書き込みテスト', () => {
+  test.slow(); // タイムアウトを3倍に延長
+
+  test('すべてのサポートされているタグを単一のFLACファイルに書き込み、正しく保存されること', async ({
+    mainPage,
+    testDataDir
+  }) => {
+    const trackPath = join(testDataDir, 'track.flac');
+    await mainPage.dropZone.dropFiles([trackPath]);
+
+    await expect(mainPage.trackGrid.rows).toHaveCount(1, { timeout: 10000 });
+    await mainPage.trackGrid.selectTrack(0);
+
+    // 全てのフィールドに値を設定
+    await mainPage.inspector.basicFields.setTitle('Full Tag Title');
+    await mainPage.inspector.basicFields.setAlbum('Full Tag Album');
+    await mainPage.inspector.numericFields.setDate('2025');
+    await mainPage.inspector.numericFields.setTrackNumber('7');
+    await mainPage.inspector.numericFields.setTrackTotal('12');
+    await mainPage.inspector.numericFields.setDiscNumber('1');
+    await mainPage.inspector.numericFields.setDiscTotal('2');
+    await mainPage.inspector.basicFields.setCatalogNumber('TEST-999');
+    await mainPage.inspector.basicFields.setArtists(['Artist A', 'Artist B']);
+    await mainPage.inspector.basicFields.setAlbumArtists(['Album Artist X']);
+    await mainPage.inspector.genres.setGenres(['Electronic', 'Ambient']);
+
+    // 保存実行
+    await expect(mainPage.toolbar.saveChangesButton).toBeEnabled();
+    await mainPage.toolbar.saveChangesButton.click();
+    await expect(mainPage.toolbar.saveChangesButton).toBeDisabled({ timeout: 15000 });
+
+    // アプリをリロードして再度読み込み、保存されたことを確認する
+    await mainPage.page.reload();
+    await mainPage.dropZone.dropFiles([trackPath]);
+
+    await expect(mainPage.trackGrid.rows).toHaveCount(1, { timeout: 10000 });
+    await mainPage.trackGrid.selectTrack(0);
+
+    // 全てのフィールドの値を検証
+    await expect(mainPage.inspector.basicFields.titleInput).toHaveValue('Full Tag Title');
+    await expect(mainPage.inspector.basicFields.albumInput).toHaveValue('Full Tag Album');
+    await expect(mainPage.inspector.numericFields.dateInput).toHaveValue('2025');
+    await expect(mainPage.inspector.numericFields.trackNumberInput).toHaveValue('7');
+    await expect(mainPage.inspector.numericFields.trackTotalInput).toHaveValue('12');
+    await expect(mainPage.inspector.numericFields.discNumberInput).toHaveValue('1');
+    await expect(mainPage.inspector.numericFields.discTotalInput).toHaveValue('2');
+    await expect(mainPage.inspector.basicFields.catalogNumberInput).toHaveValue('TEST-999');
+
+    expect(await mainPage.inspector.basicFields.getArtists()).toEqual(['Artist A', 'Artist B']);
+    expect(await mainPage.inspector.basicFields.getAlbumArtists()).toEqual(['Album Artist X']);
+    expect(await mainPage.inspector.genres.getGenres()).toEqual(['Electronic', 'Ambient']);
+  });
+
+  test('複数のトラックに対して一括編集可能なすべてのフィールドを編集して保存できること', async ({
+    mainPage,
+    testDataDir
+  }) => {
+    const track1 = join(testDataDir, 'track.flac');
+    const track2 = join(testDataDir, 'full-tags.flac');
+    await mainPage.dropZone.dropFiles([track1, track2]);
+
+    await expect(mainPage.trackGrid.rows).toHaveCount(2, { timeout: 10000 });
+
+    // 全選択
+    await mainPage.trackGrid.selectAll();
+
+    // 一括編集可能なフィールドを設定
+    await mainPage.inspector.basicFields.setAlbum('Batch Album');
+    await mainPage.inspector.numericFields.setDate('2030');
+    await mainPage.inspector.numericFields.setTrackTotal('20');
+    await mainPage.inspector.numericFields.setDiscNumber('3');
+    await mainPage.inspector.numericFields.setDiscTotal('5');
+    await mainPage.inspector.basicFields.setCatalogNumber('BATCH-COLLECTION');
+    await mainPage.inspector.basicFields.setArtists(['Common Artist']);
+    await mainPage.inspector.basicFields.setAlbumArtists(['Common Album Artist']);
+    await mainPage.inspector.genres.setGenres(['Classical']);
+
+    // 保存
+    await mainPage.toolbar.saveChangesButton.click();
+    await expect(mainPage.toolbar.saveChangesButton).toBeDisabled({ timeout: 15000 });
+
+    // リロードして確認
+    await mainPage.page.reload();
+    await mainPage.dropZone.dropFiles([track1, track2]);
+
+    // 両方のトラックで値が更新されていることを確認
+    for (let i = 0; i < 2; i++) {
+      await mainPage.trackGrid.selectTrack(i);
+      await expect(mainPage.inspector.basicFields.albumInput).toHaveValue('Batch Album');
+      await expect(mainPage.inspector.numericFields.dateInput).toHaveValue('2030');
+      await expect(mainPage.inspector.numericFields.trackTotalInput).toHaveValue('20');
+      await expect(mainPage.inspector.numericFields.discNumberInput).toHaveValue('3');
+      await expect(mainPage.inspector.numericFields.discTotalInput).toHaveValue('5');
+      await expect(mainPage.inspector.basicFields.catalogNumberInput).toHaveValue(
+        'BATCH-COLLECTION'
+      );
+
+      expect(await mainPage.inspector.basicFields.getArtists()).toEqual(['Common Artist']);
+      expect(await mainPage.inspector.basicFields.getAlbumArtists()).toEqual([
+        'Common Album Artist'
+      ]);
+      expect(await mainPage.inspector.genres.getGenres()).toEqual(['Classical']);
+    }
+  });
+});


### PR DESCRIPTION
GitHub Issue #185 の残課題である「タグの書き込み機能のテスト」を実装しました。

### 実施内容

1.  **POM (Page Object Model) の階層化と分割**
    *   `InspectorArea.ts` が肥大化していたため、4つのサブセクション（`Artwork`, `BasicFields`, `NumericFields`, `Genres`）に分割し、階層的な POM 構造に再編しました。
    *   委譲メソッドを排除し、各セクション経由でロケータや操作メソッドにアクセスする形に統一しました。
2.  **インスペクター操作の安定化**
    *   インスペクター内の要素操作時に `scrollIntoViewIfNeeded` と `force: true` を使用し、要素が長い場合でも確実に操作が行われるように修正しました。これにより、一括編集時などのスクロールハング問題を解消しています。
3.  **E2E テストの拡充 (`tag-writing.spec.ts`)**
    *   **単一ファイルテスト**: 全てのサポートされているタグ（Title, Album, Artists, Genres, Track No/Total, Disc No/Total, Date, Catalog Number）の書き込みと、アプリ再起動後の永続化検証を実装しました。
    *   **一括編集テスト**: 複数ファイル選択時に一括編集可能な全てのフィールドが正しく更新・保存されることを検証しました。
4.  **既存テストの修正**
    *   `tag-reading.spec.ts` を新しい階層化 POM 構造に適合させました。
5.  **POM の機能追加 (`TrackGridArea.ts`)**
    *   全選択を行う `selectAll()` メソッドを追加し、テストコードからキーボードショートカットの直接指定を排除しました。

### 検証結果
- `pnpm lint`: PASS
- `pnpm format`: PASS
- `npx playwright test tests/e2e/specs/tag-reading.spec.ts tests/e2e/specs/tag-writing.spec.ts`: PASS (4 tests)

Closes #185